### PR TITLE
Add Sky Executive detail page

### DIFF
--- a/modules/app/components/StatusText.tsx
+++ b/modules/app/components/StatusText.tsx
@@ -17,7 +17,7 @@ export const StatusText = (props: Props): JSX.Element => (
   <Text
     as="p"
     variant="caps"
-    datatest-id={props.testId}
+    data-testid={props.testId}
     sx={{ textAlign: 'center', px: [3, 4], wordBreak: 'break-word' }}
   >
     {props.children}

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -85,10 +85,7 @@ export default function ExecutiveOverviewCard({
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Box>
             <Flex sx={{ flexDirection: 'column' }}>
-              <InternalLink 
-                href={executiveUrl} 
-                title="View executive details"
-              >
+              <InternalLink href={executiveUrl} title="View executive details">
                 <>
                   <CardHeader text={postedDateString} />
                   <CardTitle title={proposal.title} styles={{ mt: 2 }} />
@@ -133,10 +130,7 @@ export default function ExecutiveOverviewCard({
                 gap: [0, 3]
               }}
             >
-              <InternalLink 
-                href={executiveUrl} 
-                title="View executive details"
-              >
+              <InternalLink href={executiveUrl} title="View executive details">
                 <Button
                   variant="outline"
                   sx={{
@@ -199,8 +193,6 @@ export default function ExecutiveOverviewCard({
           </Flex>
         </Flex>
       </Flex>
-
-      {voting && <VoteModal proposal={proposal} close={() => setVoting(false)} />}
 
       <Flex sx={{ flexDirection: 'column' }}>
         <Divider my={0} />

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -30,6 +30,7 @@ type Props = {
   account?: string;
   votedProposals: string[];
   mkrOnHat?: bigint;
+  isLegacy?: boolean;
 };
 
 export default function ExecutiveOverviewCard({
@@ -37,7 +38,8 @@ export default function ExecutiveOverviewCard({
   isHat,
   account,
   votedProposals,
-  mkrOnHat
+  mkrOnHat,
+  isLegacy = false
 }: Props): JSX.Element {
   const [voting, setVoting] = useState(false);
   const [postedDateString, setPostedDateString] = useState('');
@@ -63,6 +65,7 @@ export default function ExecutiveOverviewCard({
   }
 
   const canVote = !!account;
+  const executiveUrl = isLegacy ? `/legacy-executive/${proposal.key}` : `/executive/${proposal.key}`;
 
   return (
     <Card
@@ -83,7 +86,7 @@ export default function ExecutiveOverviewCard({
           <Box>
             <Flex sx={{ flexDirection: 'column' }}>
               <InternalLink 
-                href={`/executive/${proposal.key}`} 
+                href={executiveUrl} 
                 title="View executive details"
               >
                 <>
@@ -131,7 +134,7 @@ export default function ExecutiveOverviewCard({
               }}
             >
               <InternalLink 
-                href={`/executive/${proposal.key}`} 
+                href={executiveUrl} 
                 title="View executive details"
               >
                 <Button

--- a/modules/executive/components/SkyExecutiveDetailView.tsx
+++ b/modules/executive/components/SkyExecutiveDetailView.tsx
@@ -212,7 +212,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
           {/* Read-only notice for Sky executives */}
           <Card sx={{ p: 3, backgroundColor: 'background', border: '1px solid', borderColor: 'muted' }}>
             <Flex sx={{ alignItems: 'center', justifyContent: 'center' }}>
-              <Icon name="info" sx={{ mr: 2, color: 'primary' }} />
+              <Icon name="info" sx={{ mr: 2, color: 'primary', size: 4 }} />
               <Text sx={{ textAlign: 'center', color: 'textSecondary' }}>
                 This is a Sky governance executive. Voting is only available on{' '}
                 <ExternalLink href="https://vote.sky.money" title="Sky voting portal">

--- a/modules/executive/components/SkyExecutiveDetailView.tsx
+++ b/modules/executive/components/SkyExecutiveDetailView.tsx
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { useState } from 'react';
-import { Card, Flex, Divider, Heading, Text, Box, Button, Spinner } from 'theme-ui';
+import { Card, Flex, Divider, Heading, Text, Box, Button, Spinner, Badge } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import Icon from 'modules/app/components/Icon';
 import { formatDateWithTime } from 'lib/datetime';
@@ -124,6 +124,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
                   >
                     Posted {formatDateWithTime(new Date(executive.date))}
                   </Text>
+                  <Badge variant="sky">Sky Governance</Badge>
                 </Flex>
 
                 <Flex sx={{ mb: 2, flexDirection: 'column' }}>

--- a/modules/executive/components/SkyExecutiveDetailView.tsx
+++ b/modules/executive/components/SkyExecutiveDetailView.tsx
@@ -1,0 +1,250 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { useState } from 'react';
+import { Card, Flex, Divider, Heading, Text, Box, Button } from 'theme-ui';
+import { useBreakpointIndex } from '@theme-ui/match-media';
+import Icon from 'modules/app/components/Icon';
+import { formatDateWithTime } from 'lib/datetime';
+import PrimaryLayout from 'modules/app/components/layout/layouts/Primary';
+import SidebarLayout from 'modules/app/components/layout/layouts/Sidebar';
+import Stack from 'modules/app/components/layout/layouts/Stack';
+import Tabs from 'modules/app/components/Tabs';
+import SystemStatsSidebar from 'modules/app/components/SystemStatsSidebar';
+import ResourceBox from 'modules/app/components/ResourceBox';
+import { HeadComponent } from 'modules/app/components/layout/Head';
+import { ErrorBoundary } from 'modules/app/components/ErrorBoundary';
+import { InternalLink } from 'modules/app/components/InternalLink';
+import { ExternalLink } from 'modules/app/components/ExternalLink';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+import { StatBox } from 'modules/app/components/StatBox';
+import { getSkyStatusText } from 'modules/executive/helpers/getStatusText';
+import SkyExecutiveStatusBox from './SkyExecutiveStatusBox';
+import SkyExecutiveSupportersBreakdown from './SkyExecutiveSupportersBreakdown';
+
+const editMarkdown = (content: string) => {
+  // hide the duplicate proposal title
+  return (
+    content
+      .replace(/^<h1>.*<\/h1>|^<h2>.*<\/h2>/, '')
+      // fixes issue with older images that are too large
+      .replace(/(<img)(.*src=".*")(>)/g, '$1 width="100%"$2$3')
+  );
+};
+
+type SkyExecutiveDetailViewProps = {
+  executive: SkyExecutiveDetailResponse;
+  skyOnHat?: bigint;
+};
+
+const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewProps) => {
+  const bpi = useBreakpointIndex({ defaultIndex: 2 });
+  const [showAllSupporters, setShowAllSupporters] = useState(false);
+
+  const isHat = executive.spellData?.hasBeenCast || false;
+
+  return (
+    <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+      <SidebarLayout>
+        <HeadComponent 
+          title={executive.title} 
+          description={`${executive.title}. ${executive.proposalBlurb}`} 
+        />
+
+        <div>
+          <Flex mb={2} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+            <InternalLink href="/executive" title="View executive proposals">
+              <Button variant="mutedOutline">
+                <Flex sx={{ display: ['none', 'block'], alignItems: 'center', whiteSpace: 'nowrap' }}>
+                  <Icon name="chevron_left" sx={{ size: 2, mr: 2 }} />
+                  Back to Execs
+                </Flex>
+                <Flex sx={{ display: ['block', 'none'], alignItems: 'center', whiteSpace: 'nowrap' }}>
+                  Back to Execs
+                </Flex>
+              </Button>
+            </InternalLink>
+            <Flex sx={{ justifyContent: 'space-between' }}>
+              {executive.ctx?.prev?.key && (
+                <InternalLink
+                  href={`/executive/${executive.ctx.prev.key}`}
+                  title="View previous executive"
+                  scroll={false}
+                >
+                  <Button variant="mutedOutline">
+                    <Flex sx={{ alignItems: 'center', whiteSpace: 'nowrap' }}>
+                      <Icon name="chevron_left" sx={{ size: 2, mr: 2 }} />
+                      {bpi > 0 ? 'Previous Exec' : 'Previous'}
+                    </Flex>
+                  </Button>
+                </InternalLink>
+              )}
+              {executive.ctx?.next?.key && (
+                <InternalLink
+                  href={`/executive/${executive.ctx.next.key}`}
+                  title="View next executive"
+                  scroll={false}
+                  styles={{ ml: 2 }}
+                >
+                  <Button variant="mutedOutline">
+                    <Flex sx={{ alignItems: 'center', whiteSpace: 'nowrap' }}>
+                      {bpi > 0 ? 'Next Exec' : 'Next'}
+                      <Icon name="chevron_right" sx={{ size: 2, ml: 2 }} />
+                    </Flex>
+                  </Button>
+                </InternalLink>
+              )}
+            </Flex>
+          </Flex>
+          
+          <Card sx={{ p: [0, 0] }}>
+            <Flex sx={{ flexDirection: 'column', px: [3, 4], pt: [3, 4] }}>
+              <Box>
+                <Flex sx={{ justifyContent: 'space-between', flexDirection: ['column', 'row'] }}>
+                  <Text
+                    variant="caps"
+                    sx={{
+                      fontSize: [1],
+                      color: 'textSecondary'
+                    }}
+                  >
+                    Posted {formatDateWithTime(new Date(executive.date))} | Executive Key {executive.key}
+                  </Text>
+                </Flex>
+
+                <Flex sx={{ mb: 2, flexDirection: 'column' }}>
+                  <Heading mt="2" sx={{ fontSize: [5, 6] }}>
+                    {executive.title}
+                  </Heading>
+
+                  <Text sx={{ my: 2, color: 'textSecondary' }}>
+                    {executive.proposalBlurb}
+                  </Text>
+
+                  <Flex sx={{ justifyContent: 'space-between', mb: 2, flexDirection: 'column' }}>
+                    {executive.proposalLink && (
+                      <Box>
+                        <ExternalLink title="View on Sky Portal" href={executive.proposalLink}>
+                          <Text sx={{ fontSize: 3, fontWeight: 'semiBold' }}>
+                            View on Sky Portal
+                            <Icon sx={{ ml: 2 }} name="arrowTopRight" size={2} />
+                          </Text>
+                        </ExternalLink>
+                      </Box>
+                    )}
+                  </Flex>
+
+                  {/* Executive Stats */}
+                  <Flex sx={{ justifyContent: 'space-between', mb: 3 }}>
+                    <StatBox
+                      value={executive.address}
+                      label="Spell Address"
+                      styles={{ fontSize: [2, 3] }}
+                    />
+                    <StatBox
+                      value={executive.spellData?.skySupport ? 
+                        Math.floor(parseFloat(executive.spellData.skySupport)).toLocaleString() : 
+                        undefined
+                      }
+                      label="SKY Support"
+                    />
+                    <StatBox
+                      value={executive.supporters?.length || 0}
+                      label="Supporters"
+                    />
+                  </Flex>
+
+                  {/* Executive Badges */}
+                  <Flex sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+                    {isHat && (
+                      <Box
+                        sx={{
+                          borderRadius: '12px',
+                          padding: '4px 8px',
+                          display: 'flex',
+                          alignItems: 'center',
+                          color: 'tagColorThree',
+                          backgroundColor: 'tagColorThreeBg',
+                          my: 2
+                        }}
+                      >
+                        <Text sx={{ fontSize: 2 }}>Governing Proposal</Text>
+                      </Box>
+                    )}
+                  </Flex>
+                </Flex>
+              </Box>
+            </Flex>
+
+            <Tabs
+              tabListStyles={{ pl: [3, 4] }}
+              tabTitles={['Supporters', 'Executive Detail']}
+              tabRoutes={['Supporters', 'Executive Detail']}
+              tabPanels={[
+                <div key="supporters">
+                  <SkyExecutiveSupportersBreakdown 
+                    executive={executive} 
+                    showAll={showAllSupporters}
+                    onShowAll={() => setShowAllSupporters(true)}
+                  />
+                </div>,
+                <div key="executive-detail">
+                  <Box
+                    data-testid="executive-detail"
+                    sx={{ variant: 'markdown.default', p: [3, 4] }}
+                    dangerouslySetInnerHTML={{ __html: editMarkdown(executive.content || executive.proposalBlurb) }}
+                  />
+                </div>
+              ]}
+              banner={
+                <Box>
+                  <Divider my={0} />
+                  <SkyExecutiveStatusBox executive={executive} skyOnHat={skyOnHat} />
+                  <Divider my={0} />
+                </Box>
+              }
+            />
+          </Card>
+        </div>
+        
+        <Stack gap={3}>
+          {/* Read-only notice for Sky executives */}
+          <Card sx={{ p: 3, backgroundColor: 'background', border: '1px solid', borderColor: 'muted' }}>
+            <Flex sx={{ alignItems: 'center', justifyContent: 'center' }}>
+              <Icon name="info" sx={{ mr: 2, color: 'primary' }} />
+              <Text sx={{ textAlign: 'center', color: 'textSecondary' }}>
+                This is a Sky governance executive. Voting is only available on{' '}
+                <ExternalLink href="https://vote.sky.money" title="Sky voting portal">
+                  <Text>vote.sky.money</Text>
+                </ExternalLink>
+              </Text>
+            </Flex>
+          </Card>
+          
+          <ErrorBoundary componentName="System Info">
+            <SystemStatsSidebar
+              fields={[
+                'polling contract v2',
+                'polling contract v1',
+                'arbitrum polling contract',
+                'savings rate',
+                'total dai',
+                'debt ceiling',
+                'system surplus'
+              ]}
+            />
+          </ErrorBoundary>
+          <ResourceBox type={'executive'} />
+          <ResourceBox type={'general'} />
+        </Stack>
+      </SidebarLayout>
+    </PrimaryLayout>
+  );
+};
+
+export default SkyExecutiveDetailView;

--- a/modules/executive/components/SkyExecutiveDetailView.tsx
+++ b/modules/executive/components/SkyExecutiveDetailView.tsx
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { useState } from 'react';
-import { Card, Flex, Divider, Heading, Text, Box, Button } from 'theme-ui';
+import { Card, Flex, Divider, Heading, Text, Box, Button, Spinner } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import Icon from 'modules/app/components/Icon';
 import { formatDateWithTime } from 'lib/datetime';
@@ -23,9 +23,11 @@ import { InternalLink } from 'modules/app/components/InternalLink';
 import { ExternalLink } from 'modules/app/components/ExternalLink';
 import { SkyExecutiveDetailResponse } from 'modules/executive/types';
 import { StatBox } from 'modules/app/components/StatBox';
-import { getSkyStatusText } from 'modules/executive/helpers/getStatusText';
+import { formatValue } from 'lib/string';
+import { parseUnits } from 'viem';
+import { useSkyExecutiveSupportersForSpell } from 'modules/executive/hooks/useSkyExecutiveSupporters';
+import AddressIconBox from 'modules/address/components/AddressIconBox';
 import SkyExecutiveStatusBox from './SkyExecutiveStatusBox';
-import SkyExecutiveSupportersBreakdown from './SkyExecutiveSupportersBreakdown';
 
 const editMarkdown = (content: string) => {
   // hide the duplicate proposal title
@@ -46,14 +48,21 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
   const [showAllSupporters, setShowAllSupporters] = useState(false);
 
+  // Fetch supporters data from Sky API
+  const {
+    supporters,
+    loading: supportersLoading,
+    error: supportersError
+  } = useSkyExecutiveSupportersForSpell(executive.address);
+
   const isHat = executive.spellData?.hasBeenCast || false;
 
   return (
     <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
       <SidebarLayout>
-        <HeadComponent 
-          title={executive.title} 
-          description={`${executive.title}. ${executive.proposalBlurb}`} 
+        <HeadComponent
+          title={executive.title}
+          description={`${executive.title}. ${executive.proposalBlurb}`}
         />
 
         <div>
@@ -101,7 +110,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
               )}
             </Flex>
           </Flex>
-          
+
           <Card sx={{ p: [0, 0] }}>
             <Flex sx={{ flexDirection: 'column', px: [3, 4], pt: [3, 4] }}>
               <Box>
@@ -113,7 +122,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
                       color: 'textSecondary'
                     }}
                   >
-                    Posted {formatDateWithTime(new Date(executive.date))} | Executive Key {executive.key}
+                    Posted {formatDateWithTime(new Date(executive.date))}
                   </Text>
                 </Flex>
 
@@ -122,9 +131,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
                     {executive.title}
                   </Heading>
 
-                  <Text sx={{ my: 2, color: 'textSecondary' }}>
-                    {executive.proposalBlurb}
-                  </Text>
+                  <Text sx={{ my: 2, color: 'textSecondary' }}>{executive.proposalBlurb}</Text>
 
                   <Flex sx={{ justifyContent: 'space-between', mb: 2, flexDirection: 'column' }}>
                     {executive.proposalLink && (
@@ -141,22 +148,16 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
 
                   {/* Executive Stats */}
                   <Flex sx={{ justifyContent: 'space-between', mb: 3 }}>
+                    <StatBox value={executive.address} label="Spell Address" styles={{ fontSize: [2, 3] }} />
                     <StatBox
-                      value={executive.address}
-                      label="Spell Address"
-                      styles={{ fontSize: [2, 3] }}
-                    />
-                    <StatBox
-                      value={executive.spellData?.skySupport ? 
-                        Math.floor(parseFloat(executive.spellData.skySupport)).toLocaleString() : 
-                        undefined
+                      value={
+                        executive.spellData?.skySupport
+                          ? formatValue(BigInt(executive.spellData.skySupport))
+                          : undefined
                       }
                       label="SKY Support"
                     />
-                    <StatBox
-                      value={executive.supporters?.length || 0}
-                      label="Supporters"
-                    />
+                    <StatBox value={supporters.length.toString()} label="Supporters" />
                   </Flex>
 
                   {/* Executive Badges */}
@@ -183,21 +184,16 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
 
             <Tabs
               tabListStyles={{ pl: [3, 4] }}
-              tabTitles={['Supporters', 'Executive Detail']}
-              tabRoutes={['Supporters', 'Executive Detail']}
+              tabTitles={['Executive Detail']}
+              tabRoutes={['Executive Detail']}
               tabPanels={[
-                <div key="supporters">
-                  <SkyExecutiveSupportersBreakdown 
-                    executive={executive} 
-                    showAll={showAllSupporters}
-                    onShowAll={() => setShowAllSupporters(true)}
-                  />
-                </div>,
                 <div key="executive-detail">
                   <Box
                     data-testid="executive-detail"
                     sx={{ variant: 'markdown.default', p: [3, 4] }}
-                    dangerouslySetInnerHTML={{ __html: editMarkdown(executive.content || executive.proposalBlurb) }}
+                    dangerouslySetInnerHTML={{
+                      __html: editMarkdown(executive.content || executive.proposalBlurb)
+                    }}
                   />
                 </div>
               ]}
@@ -211,7 +207,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
             />
           </Card>
         </div>
-        
+
         <Stack gap={3}>
           {/* Read-only notice for Sky executives */}
           <Card sx={{ p: 3, backgroundColor: 'background', border: '1px solid', borderColor: 'muted' }}>
@@ -225,7 +221,126 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
               </Text>
             </Flex>
           </Card>
-          
+
+          {/* Supporters List */}
+          <Box>
+            <Flex sx={{ mt: 3, mb: 2, alignItems: 'center', justifyContent: 'space-between' }}>
+              <Heading as="h3" variant="microHeading" sx={{ mr: 1 }}>
+                Supporters
+              </Heading>
+              <Flex sx={{ alignItems: 'center' }}>
+                <Box sx={{ pt: '3px', mr: 1 }}>
+                  <Icon name="info" color="textSecondary" size={14} />
+                </Box>
+                <Text sx={{ fontSize: 1, color: 'textSecondary' }}>Updated every five minutes</Text>
+              </Flex>
+            </Flex>
+            <ErrorBoundary componentName="Sky Executive Supporters">
+              <Card variant="compact" p={3}>
+                <Box>
+                  {supportersLoading && !supportersError && (
+                    <Flex
+                      sx={{
+                        height: '100%',
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                      }}
+                    >
+                      <Spinner size={32} />
+                    </Flex>
+                  )}
+
+                  {supportersError && (
+                    <Flex
+                      sx={{
+                        height: '100%',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        fontSize: 4,
+                        color: 'onSecondary'
+                      }}
+                    >
+                      List of supporters currently unavailable
+                    </Flex>
+                  )}
+                  {!supportersLoading && !supportersError && supporters.length === 0 && (
+                    <Flex
+                      sx={{
+                        height: '100%',
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                      }}
+                    >
+                      <Text>Currently there are no supporters</Text>
+                    </Flex>
+                  )}
+
+                  <Flex sx={{ flexDirection: 'column' }}>
+                    {supporters.slice(0, showAllSupporters ? supporters.length : 10).map(supporter => (
+                      <Flex
+                        sx={{
+                          justifyContent: 'space-between',
+                          alignItems: 'flex-start',
+                          ':not(:last-child)': {
+                            mb: 2
+                          }
+                        }}
+                        key={supporter.address}
+                      >
+                        <InternalLink
+                          href={`/address/${supporter.address}`}
+                          title="Profile details"
+                          styles={{ maxWidth: '265px' }}
+                        >
+                          <Text
+                            sx={{
+                              color: 'accentBlue',
+                              fontSize: 2,
+                              ':hover': { color: 'accentBlueEmphasis' }
+                            }}
+                          >
+                            <AddressIconBox address={supporter.address} width={30} limitTextLength={70} />
+                          </Text>
+                        </InternalLink>
+                        <Flex sx={{ flexDirection: 'column', alignItems: 'flex-end' }}>
+                          <Text>
+                            {parseFloat(supporter.percent) > 0.01
+                              ? parseFloat(supporter.percent).toFixed(2)
+                              : '<0.01'}
+                            %
+                          </Text>
+                          <Text color="onSecondary" sx={{ fontSize: 2 }}>
+                            {formatValue(
+                              parseUnits(supporter.deposits, 18),
+                              undefined,
+                              undefined,
+                              true,
+                              true
+                            )}{' '}
+                            SKY
+                          </Text>
+                        </Flex>
+                      </Flex>
+                    ))}
+
+                    {!showAllSupporters && supporters.length > 10 && (
+                      <Button
+                        onClick={() => setShowAllSupporters(true)}
+                        variant="outline"
+                        data-testid="button-show-more-sky-executive-supporters"
+                        sx={{ mt: 2, alignSelf: 'center' }}
+                      >
+                        <Text color="text" variant="caps">
+                          Show all supporters
+                        </Text>
+                      </Button>
+                    )}
+                  </Flex>
+                </Box>
+              </Card>
+            </ErrorBoundary>
+          </Box>
+
           <ErrorBoundary componentName="System Info">
             <SystemStatsSidebar
               fields={[

--- a/modules/executive/components/SkyExecutiveOverviewCard.tsx
+++ b/modules/executive/components/SkyExecutiveOverviewCard.tsx
@@ -12,6 +12,7 @@ import Skeleton from 'modules/app/components/SkeletonThemed';
 import { formatDateWithoutTime } from 'lib/datetime';
 import { getSkyStatusText } from 'modules/executive/helpers/getStatusText';
 import { ExternalLink } from 'modules/app/components/ExternalLink';
+import { InternalLink } from 'modules/app/components/InternalLink';
 import { SkyProposal } from 'modules/executive/types';
 import { CardHeader } from 'modules/app/components/Card/CardHeader';
 import { CardTitle } from 'modules/app/components/Card/CardTitle';
@@ -52,8 +53,8 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Box>
             <Flex sx={{ flexDirection: 'column' }}>
-              <ExternalLink
-                href={`https://vote.sky.money/executive/${proposal.key}`}
+              <InternalLink
+                href={`/executive/${proposal.key}`}
                 title="View executive details"
               >
                 <>
@@ -61,7 +62,7 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
                   <CardTitle title={proposal.title} styles={{ mt: 2 }} />
                   <CardSummary text={proposal.proposalBlurb} styles={{ my: 2 }} />
                 </>
-              </ExternalLink>
+              </InternalLink>
               <Flex sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
                 {isHat && proposal.address !== ZERO_ADDRESS ? (
                   // TODO this should be made the primary badge component in our theme
@@ -100,8 +101,8 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
                 gap: [0, 3]
               }}
             >
-              <ExternalLink
-                href={`https://vote.sky.money/executive/${proposal.key}`}
+              <InternalLink
+                href={`/executive/${proposal.key}`}
                 title="View executive details"
               >
                 <Button
@@ -113,7 +114,7 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
                 >
                   View Details
                 </Button>
-              </ExternalLink>
+              </InternalLink>
             </Flex>
             <Flex sx={{ flexShrink: 0 }}>
               {proposal.spellData?.skySupport === undefined ? (

--- a/modules/executive/components/SkyExecutiveOverviewCard.tsx
+++ b/modules/executive/components/SkyExecutiveOverviewCard.tsx
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { useState, useEffect } from 'react';
-import { Text, Flex, Box, Button, Divider, Card } from 'theme-ui';
+import { Text, Flex, Box, Button, Divider, Card, Badge } from 'theme-ui';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { formatDateWithoutTime } from 'lib/datetime';
 import { getSkyStatusText } from 'modules/executive/helpers/getStatusText';
@@ -39,9 +39,11 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
       data-testid="sky-executive-overview-card"
       sx={{
         p: [0, 0],
-        width: '100%'
+        width: '100%',
+        position: 'relative'
       }}
     >
+      <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
       <Flex
         sx={{
           flexDirection: 'column',

--- a/modules/executive/components/SkyExecutiveStatusBox.tsx
+++ b/modules/executive/components/SkyExecutiveStatusBox.tsx
@@ -1,0 +1,34 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { Flex, Text } from 'theme-ui';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+import { StatusText } from 'modules/app/components/StatusText';
+import { getSkyStatusText } from 'modules/executive/helpers/getStatusText';
+
+type SkyExecutiveStatusBoxProps = {
+  executive: SkyExecutiveDetailResponse;
+  skyOnHat?: bigint;
+};
+
+const SkyExecutiveStatusBox = ({ executive, skyOnHat }: SkyExecutiveStatusBoxProps): JSX.Element => {
+  const statusText = getSkyStatusText({
+    spellData: executive.spellData,
+    skyOnHat
+  });
+
+  return (
+    <Flex sx={{ py: 2, justifyContent: 'center', fontSize: [1, 2], color: 'onSecondary' }}>
+      <StatusText testId="sky-executive-status">
+        {statusText}
+      </StatusText>
+    </Flex>
+  );
+};
+
+export default SkyExecutiveStatusBox;

--- a/modules/executive/components/SkyExecutiveSupportersBreakdown.tsx
+++ b/modules/executive/components/SkyExecutiveSupportersBreakdown.tsx
@@ -37,7 +37,7 @@ const SkyExecutiveSupportersBreakdown = ({
   const [sortBy, setSortBy] = useState<'skySupport' | 'percentage'>('skySupport');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
-  const hasNoSupporters = supporters.length === 0;
+  const hasNoSupporters = !supporters || supporters.length === 0;
 
   const sortedSupporters = useMemo(() => {
     if (!supporters) return [];
@@ -85,7 +85,7 @@ const SkyExecutiveSupportersBreakdown = ({
             minHeight: '200px'
           }}
         >
-          <Spinner size={32} />
+          <Spinner size={32} data-testid="loading-spinner" />
         </Flex>
       </Box>
     );
@@ -256,7 +256,7 @@ const SkyExecutiveSupportersBreakdown = ({
         </Flex>
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Text sx={{ color: 'textSecondary' }}>Total Supporters</Text>
-          <Text sx={{ fontWeight: 'semiBold' }}>{supporters.length}</Text>
+          <Text sx={{ fontWeight: 'semiBold' }}>{supporters?.length || 0}</Text>
         </Flex>
       </Box>
     </Box>

--- a/modules/executive/components/SkyExecutiveSupportersBreakdown.tsx
+++ b/modules/executive/components/SkyExecutiveSupportersBreakdown.tsx
@@ -12,27 +12,31 @@ import { SkyExecutiveDetailResponse, SkyExecutiveSupporter } from 'modules/execu
 import { InternalLink } from 'modules/app/components/InternalLink';
 import AddressIconBox from 'modules/address/components/AddressIconBox';
 import { formatValue } from 'lib/string';
-import { parseEther } from 'viem';
+import { parseUnits } from 'viem';
 import Icon from 'modules/app/components/Icon';
 
 const INITIAL_SUPPORTERS_COUNT = 10;
 
 type SkyExecutiveSupportersBreakdownProps = {
   executive: SkyExecutiveDetailResponse;
+  supporters: { address: string; deposits: string; percent: string }[];
+  loading: boolean;
+  error?: Error;
   showAll: boolean;
   onShowAll: () => void;
 };
 
 const SkyExecutiveSupportersBreakdown = ({ 
   executive, 
+  supporters,
+  loading,
+  error,
   showAll, 
   onShowAll 
 }: SkyExecutiveSupportersBreakdownProps): JSX.Element => {
   const [sortBy, setSortBy] = useState<'skySupport' | 'percentage'>('skySupport');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
-  const supporters = executive.supporters || [];
-  const loading = !supporters;
   const hasNoSupporters = supporters.length === 0;
 
   const sortedSupporters = useMemo(() => {
@@ -43,11 +47,11 @@ const SkyExecutiveSupportersBreakdown = ({
       let bValue: number;
       
       if (sortBy === 'skySupport') {
-        aValue = parseFloat(a.skySupport);
-        bValue = parseFloat(b.skySupport);
+        aValue = parseFloat(a.deposits);
+        bValue = parseFloat(b.deposits);
       } else {
-        aValue = a.percentage;
-        bValue = b.percentage;
+        aValue = parseFloat(a.percent);
+        bValue = parseFloat(b.percent);
       }
       
       return sortOrder === 'desc' ? bValue - aValue : aValue - bValue;
@@ -207,7 +211,7 @@ const SkyExecutiveSupportersBreakdown = ({
                 mr: 3
               }}
             >
-              {formatValue(parseEther(supporter.skySupport), undefined, undefined, true, true)} SKY
+              {formatValue(parseUnits(supporter.deposits, 18), undefined, undefined, true, true)} SKY
             </Text>
             
             <Text
@@ -218,7 +222,7 @@ const SkyExecutiveSupportersBreakdown = ({
                 textAlign: 'right'
               }}
             >
-              {supporter.percentage > 0.01 ? supporter.percentage.toFixed(2) : '<0.01'}%
+              {parseFloat(supporter.percent) > 0.01 ? parseFloat(supporter.percent).toFixed(2) : '<0.01'}%
             </Text>
           </Flex>
         ))}
@@ -245,7 +249,7 @@ const SkyExecutiveSupportersBreakdown = ({
           <Text sx={{ color: 'textSecondary' }}>Total SKY Support</Text>
           <Text sx={{ fontWeight: 'semiBold' }}>
             {executive.spellData?.skySupport ? 
-              Math.floor(parseFloat(executive.spellData.skySupport)).toLocaleString() : 
+              formatValue(parseUnits(executive.spellData.skySupport, 18)) : 
               '0'
             } SKY
           </Text>

--- a/modules/executive/components/SkyExecutiveSupportersBreakdown.tsx
+++ b/modules/executive/components/SkyExecutiveSupportersBreakdown.tsx
@@ -1,0 +1,262 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { useState, useMemo } from 'react';
+import { Box, Flex, Text, Button, Spinner } from 'theme-ui';
+import { SkyExecutiveDetailResponse, SkyExecutiveSupporter } from 'modules/executive/types';
+import { InternalLink } from 'modules/app/components/InternalLink';
+import AddressIconBox from 'modules/address/components/AddressIconBox';
+import { formatValue } from 'lib/string';
+import { parseEther } from 'viem';
+import Icon from 'modules/app/components/Icon';
+
+const INITIAL_SUPPORTERS_COUNT = 10;
+
+type SkyExecutiveSupportersBreakdownProps = {
+  executive: SkyExecutiveDetailResponse;
+  showAll: boolean;
+  onShowAll: () => void;
+};
+
+const SkyExecutiveSupportersBreakdown = ({ 
+  executive, 
+  showAll, 
+  onShowAll 
+}: SkyExecutiveSupportersBreakdownProps): JSX.Element => {
+  const [sortBy, setSortBy] = useState<'skySupport' | 'percentage'>('skySupport');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  const supporters = executive.supporters || [];
+  const loading = !supporters;
+  const hasNoSupporters = supporters.length === 0;
+
+  const sortedSupporters = useMemo(() => {
+    if (!supporters) return [];
+    
+    const sorted = [...supporters].sort((a, b) => {
+      let aValue: number;
+      let bValue: number;
+      
+      if (sortBy === 'skySupport') {
+        aValue = parseFloat(a.skySupport);
+        bValue = parseFloat(b.skySupport);
+      } else {
+        aValue = a.percentage;
+        bValue = b.percentage;
+      }
+      
+      return sortOrder === 'desc' ? bValue - aValue : aValue - bValue;
+    });
+    
+    return showAll ? sorted : sorted.slice(0, INITIAL_SUPPORTERS_COUNT);
+  }, [supporters, sortBy, sortOrder, showAll]);
+
+  const handleSort = (field: 'skySupport' | 'percentage') => {
+    if (sortBy === field) {
+      setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc');
+    } else {
+      setSortBy(field);
+      setSortOrder('desc');
+    }
+  };
+
+  const getSortIcon = (field: 'skySupport' | 'percentage') => {
+    if (sortBy !== field) return 'chevron_down';
+    return sortOrder === 'desc' ? 'chevron_down' : 'chevron_up';
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ p: [3, 4] }}>
+        <Flex
+          sx={{
+            height: '100%',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '200px'
+          }}
+        >
+          <Spinner size={32} />
+        </Flex>
+      </Box>
+    );
+  }
+
+  if (hasNoSupporters) {
+    return (
+      <Box sx={{ p: [3, 4] }}>
+        <Text variant="microHeading" sx={{ mb: 3 }}>
+          Supporters
+        </Text>
+        <Flex
+          sx={{
+            height: '100%',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '200px'
+          }}
+        >
+          <Text sx={{ color: 'textSecondary' }}>Currently there are no supporters</Text>
+        </Flex>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: [3, 4] }}>
+      <Text variant="microHeading" sx={{ mb: 3 }}>
+        Supporters
+      </Text>
+      
+      {/* Table Header */}
+      <Flex
+        sx={{
+          borderBottom: '1px solid',
+          borderColor: 'muted',
+          pb: 2,
+          mb: 2
+        }}
+      >
+        <Text
+          sx={{
+            flex: 1,
+            fontSize: 2,
+            fontWeight: 'semiBold',
+            color: 'textSecondary'
+          }}
+        >
+          Address
+        </Text>
+        <Button
+          variant="ghost"
+          onClick={() => handleSort('skySupport')}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: 2,
+            fontWeight: 'semiBold',
+            color: 'textSecondary',
+            minWidth: '120px',
+            justifyContent: 'flex-end'
+          }}
+        >
+          SKY Support
+          <Icon name={getSortIcon('skySupport')} sx={{ ml: 1, size: 1 }} />
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() => handleSort('percentage')}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: 2,
+            fontWeight: 'semiBold',
+            color: 'textSecondary',
+            minWidth: '100px',
+            justifyContent: 'flex-end'
+          }}
+        >
+          Percentage
+          <Icon name={getSortIcon('percentage')} sx={{ ml: 1, size: 1 }} />
+        </Button>
+      </Flex>
+
+      {/* Supporters List */}
+      <Box>
+        {sortedSupporters.map((supporter) => (
+          <Flex
+            key={supporter.address}
+            sx={{
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              py: 2,
+              borderBottom: '1px solid',
+              borderColor: 'muted',
+              ':last-child': {
+                borderBottom: 'none'
+              }
+            }}
+          >
+            <InternalLink
+              href={`/address/${supporter.address}`}
+              title="Profile details"
+              styles={{ flex: 1, maxWidth: '50%' }}
+            >
+              <Text
+                sx={{
+                  color: 'accentBlue',
+                  fontSize: 2,
+                  ':hover': { color: 'accentBlueEmphasis' }
+                }}
+              >
+                <AddressIconBox address={supporter.address} width={30} limitTextLength={70} />
+              </Text>
+            </InternalLink>
+            
+            <Text
+              sx={{
+                fontSize: 2,
+                fontWeight: 'semiBold',
+                minWidth: '120px',
+                textAlign: 'right',
+                mr: 3
+              }}
+            >
+              {formatValue(parseEther(supporter.skySupport), undefined, undefined, true, true)} SKY
+            </Text>
+            
+            <Text
+              sx={{
+                fontSize: 2,
+                color: 'textSecondary',
+                minWidth: '100px',
+                textAlign: 'right'
+              }}
+            >
+              {supporter.percentage > 0.01 ? supporter.percentage.toFixed(2) : '<0.01'}%
+            </Text>
+          </Flex>
+        ))}
+      </Box>
+
+      {/* Show More Button */}
+      {!showAll && supporters.length > INITIAL_SUPPORTERS_COUNT && (
+        <Box sx={{ mt: 3, textAlign: 'center' }}>
+          <Button
+            variant="outline"
+            onClick={onShowAll}
+            data-testid="button-show-more-sky-executive-supporters"
+          >
+            <Text color="text" variant="caps">
+              Show all {supporters.length} supporters
+            </Text>
+          </Button>
+        </Box>
+      )}
+
+      {/* Summary Stats */}
+      <Box sx={{ mt: 3, pt: 3, borderTop: '1px solid', borderColor: 'muted' }}>
+        <Flex sx={{ justifyContent: 'space-between', mb: 2 }}>
+          <Text sx={{ color: 'textSecondary' }}>Total SKY Support</Text>
+          <Text sx={{ fontWeight: 'semiBold' }}>
+            {executive.spellData?.skySupport ? 
+              Math.floor(parseFloat(executive.spellData.skySupport)).toLocaleString() : 
+              '0'
+            } SKY
+          </Text>
+        </Flex>
+        <Flex sx={{ justifyContent: 'space-between' }}>
+          <Text sx={{ color: 'textSecondary' }}>Total Supporters</Text>
+          <Text sx={{ fontWeight: 'semiBold' }}>{supporters.length}</Text>
+        </Flex>
+      </Box>
+    </Box>
+  );
+};
+
+export default SkyExecutiveSupportersBreakdown;

--- a/modules/executive/components/__tests__/SkyExecutiveStatusBox.test.tsx
+++ b/modules/executive/components/__tests__/SkyExecutiveStatusBox.test.tsx
@@ -4,9 +4,11 @@ import theme from 'lib/theme';
 import SkyExecutiveStatusBox from '../SkyExecutiveStatusBox';
 import { SkyExecutiveDetailResponse } from 'modules/executive/types';
 
+import { vi } from 'vitest';
+
 // Mock the getSkyStatusText function
-jest.mock('modules/executive/helpers/getStatusText', () => ({
-  getSkyStatusText: jest.fn(() => 'Scheduled for execution')
+vi.mock('modules/executive/helpers/getStatusText', () => ({
+  getSkyStatusText: vi.fn(() => 'Scheduled for execution')
 }));
 
 const mockExecutive: SkyExecutiveDetailResponse = {

--- a/modules/executive/components/__tests__/SkyExecutiveStatusBox.test.tsx
+++ b/modules/executive/components/__tests__/SkyExecutiveStatusBox.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'theme-ui';
+import theme from 'lib/theme';
+import SkyExecutiveStatusBox from '../SkyExecutiveStatusBox';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+
+// Mock the getSkyStatusText function
+jest.mock('modules/executive/helpers/getStatusText', () => ({
+  getSkyStatusText: jest.fn(() => 'Scheduled for execution')
+}));
+
+const mockExecutive: SkyExecutiveDetailResponse = {
+  title: 'Test Executive',
+  proposalBlurb: 'Test proposal blurb',
+  key: 'test-executive',
+  address: '0x1234567890123456789012345678901234567890',
+  date: '2023-01-01T00:00:00Z',
+  content: 'Test content',
+  active: true,
+  proposalLink: 'https://vote.sky.money/executive/test-executive',
+  spellData: {
+    hasBeenCast: false,
+    hasBeenScheduled: true,
+    nextCastTime: '2023-01-02T00:00:00Z',
+    datePassed: '2023-01-01T12:00:00Z',
+    dateExecuted: '',
+    skySupport: '1000000',
+    executiveHash: '0xabcdef',
+    officeHours: 'true'
+  }
+};
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+};
+
+describe('SkyExecutiveStatusBox', () => {
+  it('renders status text correctly', () => {
+    renderWithTheme(<SkyExecutiveStatusBox executive={mockExecutive} />);
+    
+    expect(screen.getByText('Scheduled for execution')).toBeInTheDocument();
+  });
+
+  it('renders with correct test ID', () => {
+    renderWithTheme(<SkyExecutiveStatusBox executive={mockExecutive} />);
+    
+    expect(screen.getByTestId('sky-executive-status')).toBeInTheDocument();
+  });
+
+  it('renders with custom skyOnHat value', () => {
+    const skyOnHat = BigInt('500000');
+    renderWithTheme(<SkyExecutiveStatusBox executive={mockExecutive} skyOnHat={skyOnHat} />);
+    
+    expect(screen.getByTestId('sky-executive-status')).toBeInTheDocument();
+  });
+
+  it('handles different spell data states', () => {
+    const castExecutive = {
+      ...mockExecutive,
+      spellData: {
+        ...mockExecutive.spellData,
+        hasBeenCast: true,
+        hasBeenScheduled: true,
+        dateExecuted: '2023-01-02T12:00:00Z'
+      }
+    };
+
+    renderWithTheme(<SkyExecutiveStatusBox executive={castExecutive} />);
+    
+    expect(screen.getByTestId('sky-executive-status')).toBeInTheDocument();
+  });
+});

--- a/modules/executive/components/__tests__/SkyExecutiveSupportersBreakdown.test.tsx
+++ b/modules/executive/components/__tests__/SkyExecutiveSupportersBreakdown.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider } from 'theme-ui';
+import theme from 'lib/theme';
+import SkyExecutiveSupportersBreakdown from '../SkyExecutiveSupportersBreakdown';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+
+// Mock the AddressIconBox component
+jest.mock('modules/address/components/AddressIconBox', () => {
+  return function MockAddressIconBox({ address }: { address: string }) {
+    return <div data-testid="address-icon-box">{address.slice(0, 6)}...</div>;
+  };
+});
+
+// Mock the InternalLink component
+jest.mock('modules/app/components/InternalLink', () => {
+  return function MockInternalLink({ 
+    children, 
+    href 
+  }: { 
+    children: React.ReactNode; 
+    href: string; 
+  }) {
+    return <a href={href} data-testid="internal-link">{children}</a>;
+  };
+});
+
+const mockExecutive: SkyExecutiveDetailResponse = {
+  title: 'Test Executive',
+  proposalBlurb: 'Test proposal blurb',
+  key: 'test-executive',
+  address: '0x1234567890123456789012345678901234567890',
+  date: '2023-01-01T00:00:00Z',
+  content: 'Test content',
+  active: true,
+  proposalLink: 'https://vote.sky.money/executive/test-executive',
+  spellData: {
+    hasBeenCast: false,
+    hasBeenScheduled: true,
+    nextCastTime: '2023-01-02T00:00:00Z',
+    datePassed: '2023-01-01T12:00:00Z',
+    dateExecuted: '',
+    skySupport: '1000000',
+    executiveHash: '0xabcdef',
+    officeHours: 'true'
+  },
+  supporters: [
+    {
+      address: '0x1234567890123456789012345678901234567890',
+      skySupport: '500000',
+      percentage: 50.0
+    },
+    {
+      address: '0x2345678901234567890123456789012345678901',
+      skySupport: '300000',
+      percentage: 30.0
+    },
+    {
+      address: '0x3456789012345678901234567890123456789012',
+      skySupport: '200000',
+      percentage: 20.0
+    }
+  ]
+};
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+};
+
+describe('SkyExecutiveSupportersBreakdown', () => {
+  it('renders supporters table correctly', () => {
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={mockExecutive}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    expect(screen.getByText('Supporters')).toBeInTheDocument();
+    expect(screen.getByText('Address')).toBeInTheDocument();
+    expect(screen.getByText('SKY Support')).toBeInTheDocument();
+    expect(screen.getByText('Percentage')).toBeInTheDocument();
+  });
+
+  it('displays supporter information correctly', () => {
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={mockExecutive}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    // Check that supporter addresses are displayed
+    expect(screen.getAllByTestId('address-icon-box')).toHaveLength(3);
+    
+    // Check SKY amounts
+    expect(screen.getByText('500,000 SKY')).toBeInTheDocument();
+    expect(screen.getByText('300,000 SKY')).toBeInTheDocument();
+    expect(screen.getByText('200,000 SKY')).toBeInTheDocument();
+    
+    // Check percentages
+    expect(screen.getByText('50.00%')).toBeInTheDocument();
+    expect(screen.getByText('30.00%')).toBeInTheDocument();
+    expect(screen.getByText('20.00%')).toBeInTheDocument();
+  });
+
+  it('handles sorting by SKY support', async () => {
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={mockExecutive}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    const skyButton = screen.getByRole('button', { name: /SKY Support/ });
+    fireEvent.click(skyButton);
+
+    await waitFor(() => {
+      // Should still display the same data, just potentially reordered
+      expect(screen.getByText('500,000 SKY')).toBeInTheDocument();
+    });
+  });
+
+  it('handles sorting by percentage', async () => {
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={mockExecutive}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    const percentageButton = screen.getByRole('button', { name: /Percentage/ });
+    fireEvent.click(percentageButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('50.00%')).toBeInTheDocument();
+    });
+  });
+
+  it('displays summary stats correctly', () => {
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={mockExecutive}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    expect(screen.getByText('Total SKY Support')).toBeInTheDocument();
+    expect(screen.getByText('1,000,000 SKY')).toBeInTheDocument();
+    expect(screen.getByText('Total Supporters')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('handles empty supporters list', () => {
+    const emptyExecutive = {
+      ...mockExecutive,
+      supporters: []
+    };
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={emptyExecutive}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    expect(screen.getByText('Currently there are no supporters')).toBeInTheDocument();
+  });
+
+  it('handles missing supporters data', () => {
+    const executiveWithoutSupporters = {
+      ...mockExecutive,
+      supporters: undefined
+    };
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={executiveWithoutSupporters}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    // Should show loading spinner when supporters is undefined
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('calls onShowAll when show all button is clicked', () => {
+    // Create executive with many supporters to show the button
+    const executiveWithManySupporters = {
+      ...mockExecutive,
+      supporters: Array.from({ length: 15 }, (_, i) => ({
+        address: `0x${i.toString().padStart(40, '0')}`,
+        skySupport: '10000',
+        percentage: 1.0
+      }))
+    };
+    
+    const mockOnShowAll = jest.fn();
+    
+    renderWithTheme(
+      <SkyExecutiveSupportersBreakdown
+        executive={executiveWithManySupporters}
+        showAll={false}
+        onShowAll={mockOnShowAll}
+      />
+    );
+
+    const showAllButton = screen.getByRole('button', { name: /Show all 15 supporters/ });
+    fireEvent.click(showAllButton);
+
+    expect(mockOnShowAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/modules/executive/components/__tests__/SkyExecutiveSupportersBreakdown.test.tsx
+++ b/modules/executive/components/__tests__/SkyExecutiveSupportersBreakdown.test.tsx
@@ -70,17 +70,17 @@ const mockExecutive: SkyExecutiveDetailResponse = {
 const mockSupporters = [
   {
     address: '0x1234567890123456789012345678901234567890',
-    deposits: '500000000000000000000000',
+    deposits: '500000',
     percent: '50.00'
   },
   {
     address: '0x2345678901234567890123456789012345678901',
-    deposits: '300000000000000000000000',
+    deposits: '300000',
     percent: '30.00'
   },
   {
     address: '0x3456789012345678901234567890123456789012',
-    deposits: '200000000000000000000000',
+    deposits: '200000',
     percent: '20.00'
   }
 ];
@@ -235,7 +235,7 @@ describe('SkyExecutiveSupportersBreakdown', () => {
     // Create many supporters to show the button
     const manySupporters = Array.from({ length: 15 }, (_, i) => ({
       address: `0x${i.toString().padStart(40, '0')}`,
-      deposits: '10000000000000000000000',
+      deposits: '10000',
       percent: '1.00'
     }));
     

--- a/modules/executive/helpers/getStatusText.ts
+++ b/modules/executive/helpers/getStatusText.ts
@@ -101,13 +101,18 @@ export const getSkyStatusText = ({
 
   // not expired, passed, or executed, check support level
   if (!!spellData.skySupport && !!skyOnHat) {
-    // If the new proposal has more SKY than the old proposal, but hasn't been lifted, display 0 SKY needed to pass.
-    const skyNeeded =
-      skyOnHat - BigInt(spellData.skySupport) > 0n ? skyOnHat - BigInt(spellData.skySupport) : 0n;
+    try {
+      // If the new proposal has more SKY than the old proposal, but hasn't been lifted, display 0 SKY needed to pass.
+      const skyNeeded =
+        skyOnHat - BigInt(spellData.skySupport) > 0n ? skyOnHat - BigInt(spellData.skySupport) : 0n;
 
-    return `${formatValue(skyNeeded)} additional SKY support needed to pass. Expires at ${formatDateWithTime(
-      spellData.expiration
-    )}.`;
+      return `${formatValue(skyNeeded)} additional SKY support needed to pass. Expires at ${formatDateWithTime(
+        spellData.expiration
+      )}.`;
+    } catch (error) {
+      console.error('Error calculating SKY support needed:', error);
+      return 'This proposal has not yet passed and is not available for execution.';
+    }
   }
 
   // hasn't been scheduled, executed, hasn't expired, must be active and not passed yet

--- a/modules/executive/hooks/__tests__/useSkyExecutiveDetail.test.ts
+++ b/modules/executive/hooks/__tests__/useSkyExecutiveDetail.test.ts
@@ -1,0 +1,148 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { useSkyExecutiveDetail } from '../useSkyExecutiveDetail';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+
+// Mock fetchJson
+jest.mock('lib/fetchJson', () => ({
+  fetchJson: jest.fn()
+}));
+
+const mockExecutive: SkyExecutiveDetailResponse = {
+  title: 'Test Executive',
+  proposalBlurb: 'Test proposal blurb',
+  key: 'test-executive',
+  address: '0x1234567890123456789012345678901234567890',
+  date: '2023-01-01T00:00:00Z',
+  content: 'Test content',
+  active: true,
+  proposalLink: 'https://vote.sky.money/executive/test-executive',
+  spellData: {
+    hasBeenCast: false,
+    hasBeenScheduled: true,
+    nextCastTime: '2023-01-02T00:00:00Z',
+    datePassed: '2023-01-01T12:00:00Z',
+    dateExecuted: '',
+    skySupport: '1000000',
+    executiveHash: '0xabcdef',
+    officeHours: 'true'
+  },
+  supporters: [
+    {
+      address: '0x1234567890123456789012345678901234567890',
+      skySupport: '500000',
+      percentage: 50.0
+    }
+  ]
+};
+
+const createWrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
+    {children}
+  </SWRConfig>
+);
+
+describe('useSkyExecutiveDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when no proposalIdOrKey is provided', () => {
+    const { result } = renderHook(() => useSkyExecutiveDetail(undefined), {
+      wrapper: createWrapper
+    });
+
+    expect(result.current.executive).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('fetches executive data when proposalIdOrKey is provided', async () => {
+    const { fetchJson } = require('lib/fetchJson');
+    fetchJson.mockResolvedValueOnce(mockExecutive);
+
+    const { result } = renderHook(() => useSkyExecutiveDetail('test-executive'), {
+      wrapper: createWrapper
+    });
+
+    await waitFor(() => {
+      expect(result.current.executive).toEqual(mockExecutive);
+    });
+
+    expect(fetchJson).toHaveBeenCalledWith('/api/sky/executives/test-executive');
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('handles API errors correctly', async () => {
+    const { fetchJson } = require('lib/fetchJson');
+    const error = new Error('API Error');
+    fetchJson.mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useSkyExecutiveDetail('test-executive'), {
+      wrapper: createWrapper
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(error);
+    });
+
+    expect(result.current.executive).toBeUndefined();
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('uses custom refresh interval', async () => {
+    const { fetchJson } = require('lib/fetchJson');
+    fetchJson.mockResolvedValueOnce(mockExecutive);
+
+    const { result } = renderHook(() => useSkyExecutiveDetail('test-executive', 30000), {
+      wrapper: createWrapper
+    });
+
+    await waitFor(() => {
+      expect(result.current.executive).toEqual(mockExecutive);
+    });
+
+    expect(fetchJson).toHaveBeenCalledWith('/api/sky/executives/test-executive');
+  });
+
+  it('provides mutate function', async () => {
+    const { fetchJson } = require('lib/fetchJson');
+    fetchJson.mockResolvedValueOnce(mockExecutive);
+
+    const { result } = renderHook(() => useSkyExecutiveDetail('test-executive'), {
+      wrapper: createWrapper
+    });
+
+    await waitFor(() => {
+      expect(result.current.executive).toEqual(mockExecutive);
+    });
+
+    expect(typeof result.current.mutate).toBe('function');
+  });
+
+  it('handles empty string proposalIdOrKey', () => {
+    const { result } = renderHook(() => useSkyExecutiveDetail(''), {
+      wrapper: createWrapper
+    });
+
+    expect(result.current.executive).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isValidating).toBe(false);
+  });
+
+  it('handles different proposalIdOrKey formats', async () => {
+    const { fetchJson } = require('lib/fetchJson');
+    fetchJson.mockResolvedValueOnce(mockExecutive);
+
+    const { result } = renderHook(() => useSkyExecutiveDetail('exec-123'), {
+      wrapper: createWrapper
+    });
+
+    await waitFor(() => {
+      expect(result.current.executive).toEqual(mockExecutive);
+    });
+
+    expect(fetchJson).toHaveBeenCalledWith('/api/sky/executives/exec-123');
+  });
+});

--- a/modules/executive/hooks/__tests__/useSkyExecutiveDetail.test.tsx
+++ b/modules/executive/hooks/__tests__/useSkyExecutiveDetail.test.tsx
@@ -2,10 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { SWRConfig } from 'swr';
 import { useSkyExecutiveDetail } from '../useSkyExecutiveDetail';
 import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+import { vi } from 'vitest';
 
 // Mock fetchJson
-jest.mock('lib/fetchJson', () => ({
-  fetchJson: jest.fn()
+vi.mock('lib/fetchJson', () => ({
+  fetchJson: vi.fn()
 }));
 
 const mockExecutive: SkyExecutiveDetailResponse = {
@@ -44,7 +45,7 @@ const createWrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe('useSkyExecutiveDetail', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('returns undefined when no proposalIdOrKey is provided', () => {
@@ -58,8 +59,8 @@ describe('useSkyExecutiveDetail', () => {
   });
 
   it('fetches executive data when proposalIdOrKey is provided', async () => {
-    const { fetchJson } = require('lib/fetchJson');
-    fetchJson.mockResolvedValueOnce(mockExecutive);
+    const { fetchJson } = await import('lib/fetchJson');
+    vi.mocked(fetchJson).mockResolvedValueOnce(mockExecutive);
 
     const { result } = renderHook(() => useSkyExecutiveDetail('test-executive'), {
       wrapper: createWrapper
@@ -69,15 +70,15 @@ describe('useSkyExecutiveDetail', () => {
       expect(result.current.executive).toEqual(mockExecutive);
     });
 
-    expect(fetchJson).toHaveBeenCalledWith('/api/sky/executives/test-executive');
+    expect(vi.mocked(fetchJson)).toHaveBeenCalledWith('/api/sky/executives/test-executive');
     expect(result.current.error).toBeUndefined();
     expect(result.current.isValidating).toBe(false);
   });
 
   it('handles API errors correctly', async () => {
-    const { fetchJson } = require('lib/fetchJson');
+    const { fetchJson } = await import('lib/fetchJson');
     const error = new Error('API Error');
-    fetchJson.mockRejectedValueOnce(error);
+    vi.mocked(fetchJson).mockRejectedValueOnce(error);
 
     const { result } = renderHook(() => useSkyExecutiveDetail('test-executive'), {
       wrapper: createWrapper
@@ -92,8 +93,8 @@ describe('useSkyExecutiveDetail', () => {
   });
 
   it('uses custom refresh interval', async () => {
-    const { fetchJson } = require('lib/fetchJson');
-    fetchJson.mockResolvedValueOnce(mockExecutive);
+    const { fetchJson } = await import('lib/fetchJson');
+    vi.mocked(fetchJson).mockResolvedValueOnce(mockExecutive);
 
     const { result } = renderHook(() => useSkyExecutiveDetail('test-executive', 30000), {
       wrapper: createWrapper
@@ -103,12 +104,12 @@ describe('useSkyExecutiveDetail', () => {
       expect(result.current.executive).toEqual(mockExecutive);
     });
 
-    expect(fetchJson).toHaveBeenCalledWith('/api/sky/executives/test-executive');
+    expect(vi.mocked(fetchJson)).toHaveBeenCalledWith('/api/sky/executives/test-executive');
   });
 
   it('provides mutate function', async () => {
-    const { fetchJson } = require('lib/fetchJson');
-    fetchJson.mockResolvedValueOnce(mockExecutive);
+    const { fetchJson } = await import('lib/fetchJson');
+    vi.mocked(fetchJson).mockResolvedValueOnce(mockExecutive);
 
     const { result } = renderHook(() => useSkyExecutiveDetail('test-executive'), {
       wrapper: createWrapper
@@ -132,8 +133,8 @@ describe('useSkyExecutiveDetail', () => {
   });
 
   it('handles different proposalIdOrKey formats', async () => {
-    const { fetchJson } = require('lib/fetchJson');
-    fetchJson.mockResolvedValueOnce(mockExecutive);
+    const { fetchJson } = await import('lib/fetchJson');
+    vi.mocked(fetchJson).mockResolvedValueOnce(mockExecutive);
 
     const { result } = renderHook(() => useSkyExecutiveDetail('exec-123'), {
       wrapper: createWrapper
@@ -143,6 +144,6 @@ describe('useSkyExecutiveDetail', () => {
       expect(result.current.executive).toEqual(mockExecutive);
     });
 
-    expect(fetchJson).toHaveBeenCalledWith('/api/sky/executives/exec-123');
+    expect(vi.mocked(fetchJson)).toHaveBeenCalledWith('/api/sky/executives/exec-123');
   });
 });

--- a/modules/executive/hooks/useSkyExecutiveDetail.ts
+++ b/modules/executive/hooks/useSkyExecutiveDetail.ts
@@ -1,0 +1,32 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import useSWR from 'swr';
+import { fetchJson } from 'lib/fetchJson';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+
+export const useSkyExecutiveDetail = (proposalIdOrKey: string | undefined, refreshInterval = 60000) => {
+  const { data, error, isValidating, mutate } = useSWR<SkyExecutiveDetailResponse>(
+    proposalIdOrKey ? `/api/sky/executives/${proposalIdOrKey}` : null,
+    fetchJson,
+    {
+      refreshInterval,
+      revalidateOnFocus: false,
+      revalidateOnMount: true,
+      errorRetryCount: 3,
+      errorRetryInterval: 5000
+    }
+  );
+
+  return {
+    executive: data,
+    error,
+    isValidating,
+    mutate
+  };
+};

--- a/modules/executive/hooks/useSkyExecutiveSupporters.ts
+++ b/modules/executive/hooks/useSkyExecutiveSupporters.ts
@@ -1,0 +1,42 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import useSWR from 'swr';
+import { fetchJson } from 'lib/fetchJson';
+import { SkyExecutiveSupportersResponse } from 'pages/api/sky/executives/supporters';
+
+export const useSkyExecutiveSupporters = () => {
+  const { data, error, mutate } = useSWR<SkyExecutiveSupportersResponse>(
+    '/api/sky/executives/supporters',
+    fetchJson,
+    {
+      refreshInterval: 5 * 60 * 1000, // Refresh every 5 minutes
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 30 * 1000, // Dedupe requests within 30 seconds
+    }
+  );
+
+  return {
+    supporters: data,
+    loading: !error && !data,
+    error,
+    mutate,
+  };
+};
+
+export const useSkyExecutiveSupportersForSpell = (spellAddress: string) => {
+  const { supporters, loading, error, mutate } = useSkyExecutiveSupporters();
+
+  return {
+    supporters: supporters?.[spellAddress.toLowerCase()] || [],
+    loading,
+    error,
+    mutate,
+  };
+};

--- a/modules/executive/types/__tests__/skyExecutive.test.ts
+++ b/modules/executive/types/__tests__/skyExecutive.test.ts
@@ -1,0 +1,175 @@
+import { isSkyExecutive, isSkySpellData, SkyExecutiveDetailResponse } from '../skyExecutive';
+
+describe('Sky Executive Type Guards', () => {
+  describe('isSkyExecutive', () => {
+    const validSkyExecutive: SkyExecutiveDetailResponse = {
+      title: 'Test Executive',
+      proposalBlurb: 'Test proposal blurb',
+      key: 'test-executive',
+      address: '0x1234567890123456789012345678901234567890',
+      date: '2023-01-01T00:00:00Z',
+      content: 'Test content',
+      active: true,
+      proposalLink: 'https://vote.sky.money/executive/test-executive',
+      spellData: {
+        hasBeenCast: false,
+        hasBeenScheduled: true,
+        nextCastTime: '2023-01-02T00:00:00Z',
+        datePassed: '2023-01-01T12:00:00Z',
+        dateExecuted: '',
+        skySupport: '1000000',
+        executiveHash: '0xabcdef',
+        officeHours: 'true'
+      }
+    };
+
+    it('returns true for valid Sky executive', () => {
+      expect(isSkyExecutive(validSkyExecutive)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isSkyExecutive(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isSkyExecutive(undefined)).toBe(false);
+    });
+
+    it('returns false for non-object', () => {
+      expect(isSkyExecutive('string')).toBe(false);
+      expect(isSkyExecutive(123)).toBe(false);
+      expect(isSkyExecutive(true)).toBe(false);
+    });
+
+    it('returns false for object missing key field', () => {
+      const invalidExecutive = {
+        ...validSkyExecutive,
+        key: undefined
+      };
+      delete (invalidExecutive as any).key;
+      
+      expect(isSkyExecutive(invalidExecutive)).toBe(false);
+    });
+
+    it('returns false for object missing spellData field', () => {
+      const invalidExecutive = {
+        ...validSkyExecutive,
+        spellData: undefined
+      };
+      delete (invalidExecutive as any).spellData;
+      
+      expect(isSkyExecutive(invalidExecutive)).toBe(false);
+    });
+
+    it('returns false for object with spellData missing skySupport', () => {
+      const invalidExecutive = {
+        ...validSkyExecutive,
+        spellData: {
+          ...validSkyExecutive.spellData,
+          skySupport: undefined
+        }
+      };
+      delete (invalidExecutive.spellData as any).skySupport;
+      
+      expect(isSkyExecutive(invalidExecutive)).toBe(false);
+    });
+
+    it('returns false for legacy executive (without skySupport)', () => {
+      const legacyExecutive = {
+        title: 'Legacy Executive',
+        address: '0x1234567890123456789012345678901234567890',
+        spellData: {
+          hasBeenCast: false,
+          hasBeenScheduled: true,
+          mkrSupport: '1000000' // Legacy executives use mkrSupport instead of skySupport
+        }
+      };
+      
+      expect(isSkyExecutive(legacyExecutive)).toBe(false);
+    });
+
+    it('returns true for Sky executive with additional fields', () => {
+      const executiveWithExtra = {
+        ...validSkyExecutive,
+        extraField: 'extra',
+        supporters: [
+          {
+            address: '0x1234567890123456789012345678901234567890',
+            skySupport: '500000',
+            percentage: 50.0
+          }
+        ]
+      };
+      
+      expect(isSkyExecutive(executiveWithExtra)).toBe(true);
+    });
+  });
+
+  describe('isSkySpellData', () => {
+    const validSkySpellData = {
+      hasBeenCast: false,
+      hasBeenScheduled: true,
+      nextCastTime: '2023-01-02T00:00:00Z',
+      datePassed: '2023-01-01T12:00:00Z',
+      dateExecuted: '',
+      skySupport: '1000000',
+      executiveHash: '0xabcdef',
+      officeHours: 'true'
+    };
+
+    it('returns true for valid Sky spell data', () => {
+      expect(isSkySpellData(validSkySpellData)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isSkySpellData(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isSkySpellData(undefined)).toBe(false);
+    });
+
+    it('returns false for non-object', () => {
+      expect(isSkySpellData('string')).toBe(false);
+      expect(isSkySpellData(123)).toBe(false);
+      expect(isSkySpellData(true)).toBe(false);
+    });
+
+    it('returns false for object missing skySupport field', () => {
+      const invalidSpellData = {
+        ...validSkySpellData,
+        skySupport: undefined
+      };
+      delete (invalidSpellData as any).skySupport;
+      
+      expect(isSkySpellData(invalidSpellData)).toBe(false);
+    });
+
+    it('returns false for legacy spell data (with mkrSupport)', () => {
+      const legacySpellData = {
+        hasBeenCast: false,
+        hasBeenScheduled: true,
+        mkrSupport: '1000000' // Legacy spell data uses mkrSupport
+      };
+      
+      expect(isSkySpellData(legacySpellData)).toBe(false);
+    });
+
+    it('returns true for Sky spell data with additional fields', () => {
+      const spellDataWithExtra = {
+        ...validSkySpellData,
+        extraField: 'extra'
+      };
+      
+      expect(isSkySpellData(spellDataWithExtra)).toBe(true);
+    });
+
+    it('returns true for minimal Sky spell data', () => {
+      const minimalSpellData = {
+        skySupport: '1000000'
+      };
+      
+      expect(isSkySpellData(minimalSpellData)).toBe(true);
+    });
+  });
+});

--- a/modules/executive/types/index.ts
+++ b/modules/executive/types/index.ts
@@ -6,5 +6,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
-export * from './proposal';
-export * from './spellData';
+export * from './proposal.d';
+export * from './spellData.d';
+export * from './skyExecutive';

--- a/modules/executive/types/skyExecutive.ts
+++ b/modules/executive/types/skyExecutive.ts
@@ -1,0 +1,77 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+// Sky executive types for the governance portal
+
+export type SkyExecutiveSpellData = {
+  hasBeenCast: boolean;
+  hasBeenScheduled: boolean;
+  nextCastTime: string;
+  datePassed: string;
+  dateExecuted: string;
+  skySupport: string;
+  executiveHash: string;
+  officeHours: string;
+};
+
+export type SkyExecutiveSupporter = {
+  address: string;
+  skySupport: string;
+  percentage: number;
+};
+
+export type SkyExecutiveContext = {
+  prev: { key: string } | null;
+  next: { key: string } | null;
+};
+
+export type SkyExecutiveDetailResponse = {
+  title: string;
+  proposalBlurb: string;
+  key: string;
+  address: string;
+  date: string;
+  content: string; // HTML content for executive details
+  active: boolean;
+  proposalLink: string;
+  spellData: SkyExecutiveSpellData;
+  supporters?: SkyExecutiveSupporter[];
+  ctx?: SkyExecutiveContext;
+};
+
+// Sky executive list item (from the existing executives API)
+export type SkyExecutiveListItem = {
+  title: string;
+  proposalBlurb: string;
+  key: string;
+  address: string;
+  date: string;
+  active: boolean;
+  proposalLink: string;
+  spellData: SkyExecutiveSpellData;
+};
+
+// Type guard to check if an executive is a Sky executive
+export function isSkyExecutive(executive: any): executive is SkyExecutiveDetailResponse {
+  return (
+    executive &&
+    typeof executive === 'object' &&
+    'key' in executive &&
+    'spellData' in executive &&
+    'skySupport' in executive.spellData
+  );
+}
+
+// Type guard to check if spell data is Sky spell data
+export function isSkySpellData(spellData: any): spellData is SkyExecutiveSpellData {
+  return (
+    spellData &&
+    typeof spellData === 'object' &&
+    'skySupport' in spellData
+  );
+}

--- a/modules/executive/types/skyExecutive.ts
+++ b/modules/executive/types/skyExecutive.ts
@@ -9,14 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 // Sky executive types for the governance portal
 
 export type SkyExecutiveSpellData = {
-  hasBeenCast: boolean;
+  hasBeenCast?: boolean;
   hasBeenScheduled: boolean;
-  nextCastTime: string;
-  datePassed: string;
-  dateExecuted: string;
+  nextCastTime?: Date;
+  datePassed?: Date;
+  dateExecuted?: Date;
   skySupport: string;
-  executiveHash: string;
-  officeHours: string;
+  executiveHash?: string;
+  officeHours?: boolean;
 };
 
 export type SkyExecutiveSupporter = {

--- a/modules/executive/types/skyExecutive.ts
+++ b/modules/executive/types/skyExecutive.ts
@@ -59,7 +59,7 @@ export type SkyExecutiveListItem = {
 // Type guard to check if an executive is a Sky executive
 export function isSkyExecutive(executive: any): executive is SkyExecutiveDetailResponse {
   return (
-    executive &&
+    !!executive &&
     typeof executive === 'object' &&
     'key' in executive &&
     'spellData' in executive &&
@@ -70,7 +70,7 @@ export function isSkyExecutive(executive: any): executive is SkyExecutiveDetailR
 // Type guard to check if spell data is Sky spell data
 export function isSkySpellData(spellData: any): spellData is SkyExecutiveSpellData {
   return (
-    spellData &&
+    !!spellData &&
     typeof spellData === 'object' &&
     'skySupport' in spellData
   );

--- a/pages/api/sky/executives/[proposal-id-or-key].ts
+++ b/pages/api/sky/executives/[proposal-id-or-key].ts
@@ -29,6 +29,24 @@ async function fetchSkyExecutiveDetail(proposalIdOrKey: string): Promise<SkyExec
     }
 
     const data = await response.json();
+    
+    // Transform string dates to Date objects and convert officeHours to boolean
+    if (data.spellData) {
+      if (data.spellData.nextCastTime) {
+        data.spellData.nextCastTime = new Date(data.spellData.nextCastTime);
+      }
+      if (data.spellData.datePassed) {
+        data.spellData.datePassed = new Date(data.spellData.datePassed);
+      }
+      if (data.spellData.dateExecuted) {
+        data.spellData.dateExecuted = new Date(data.spellData.dateExecuted);
+      }
+      // Convert officeHours string to boolean
+      if (typeof data.spellData.officeHours === 'string') {
+        data.spellData.officeHours = data.spellData.officeHours === 'true';
+      }
+    }
+    
     return data;
   } catch (error) {
     console.error('Error fetching Sky executive detail:', error);

--- a/pages/api/sky/executives/[proposal-id-or-key].ts
+++ b/pages/api/sky/executives/[proposal-id-or-key].ts
@@ -1,0 +1,57 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { NextApiRequest, NextApiResponse } from 'next';
+import withApiHandler from 'modules/app/api/withApiHandler';
+import { ApiError } from 'modules/app/api/ApiError';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+
+async function fetchSkyExecutiveDetail(proposalIdOrKey: string): Promise<SkyExecutiveDetailResponse> {
+  try {
+    const apiUrl = `https://vote.sky.money/api/executive/${proposalIdOrKey}`;
+
+    const response = await fetch(apiUrl, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      // Add timeout for the request
+      signal: AbortSignal.timeout(10000)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sky API responded with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error fetching Sky executive detail:', error);
+    throw error;
+  }
+}
+
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    throw new ApiError('Method not allowed', 405, 'Method not allowed');
+  }
+
+  const { 'proposal-id-or-key': proposalIdOrKey } = req.query;
+
+  if (!proposalIdOrKey || typeof proposalIdOrKey !== 'string') {
+    throw new ApiError('Proposal ID or key is required', 400, 'Invalid request');
+  }
+
+  try {
+    const executive = await fetchSkyExecutiveDetail(proposalIdOrKey);
+    res.status(200).json(executive);
+  } catch (error) {
+    console.error('Sky executive detail API error:', error);
+    throw new ApiError('Failed to fetch Sky executive details', 500, 'Internal server error');
+  }
+});

--- a/pages/api/sky/executives/supporters.ts
+++ b/pages/api/sky/executives/supporters.ts
@@ -1,0 +1,62 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { NextApiRequest, NextApiResponse } from 'next';
+import withApiHandler from 'modules/app/api/withApiHandler';
+import { ApiError } from 'modules/app/api/ApiError';
+
+// Sky executive supporters API response type
+export type SkyExecutiveSupportersResponse = {
+  [spellAddress: string]: {
+    address: string;
+    deposits: string;
+    percent: string;
+  }[];
+};
+
+async function fetchSkyExecutiveSupporters(): Promise<SkyExecutiveSupportersResponse> {
+  try {
+    const apiUrl = 'https://vote.sky.money/api/executive/supporters';
+    
+    const response = await fetch(apiUrl, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      // Add timeout for the request
+      signal: AbortSignal.timeout(10000)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sky API responded with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error fetching Sky executive supporters:', error);
+    throw error;
+  }
+}
+
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'GET') {
+    throw new ApiError('Method not allowed', 405, 'Method not allowed');
+  }
+
+  // Set cache headers for 5 minutes
+  res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate');
+
+  try {
+    const supporters = await fetchSkyExecutiveSupporters();
+    res.status(200).json(supporters);
+  } catch (error) {
+    console.error('Sky executive supporters API error:', error);
+    throw new ApiError('Failed to fetch Sky executive supporters', 500, 'Internal server error');
+  }
+});

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -139,7 +139,7 @@ export default function ExecutivePage(): JSX.Element {
                               }
                             }}
                             isHat={executive.address === hatAddress}
-                            skyOnHat={skyOnHat}
+                            skyOnHat={skyOnHat || undefined}
                           />
                         </Box>
                       ))}

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -27,15 +27,23 @@ export default function ExecutivePage(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
-  const [hatAddress, setHatAddress] = useState<any>(null);
-  const [skyOnHat, setSkyOnHat] = useState<any>(null);
+  const [hatAddress, setHatAddress] = useState<string | null>(null);
+  const [skyOnHat, setSkyOnHat] = useState<bigint | null>(null);
 
   const fetchSkyHatInfo = async () => {
-    //TOD: change url to production endpoint
-    const response = await fetch('/api/sky/hat');
-    const data = await response.json();
-    setHatAddress(data.hatAddress);
-    setSkyOnHat(data.skyOnHat);
+    try {
+      //TOD: change url to production endpoint
+      const response = await fetch('/api/sky/hat');
+      const data = await response.json();
+      setHatAddress(data.hatAddress);
+      // Convert skyOnHat to BigInt if it exists and is valid
+      setSkyOnHat(data.skyOnHat ? BigInt(data.skyOnHat) : null);
+    } catch (error) {
+      console.error('Error fetching Sky hat info:', error);
+      // Set defaults if API fails
+      setHatAddress(null);
+      setSkyOnHat(null);
+    }
   };
 
   const fetchSkyExecutives = async (pageNum = 1) => {

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -135,7 +135,7 @@ export default function ExecutivePage(): JSX.Element {
                                 dateExecuted: executive.spellData.dateExecuted
                                   ? new Date(executive.spellData.dateExecuted)
                                   : undefined,
-                                officeHours: executive.spellData.officeHours === 'true'
+                                officeHours: executive.spellData.officeHours
                               }
                             }}
                             isHat={executive.address === hatAddress}

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -22,7 +22,6 @@ import { useMkrOnHat } from 'modules/executive/hooks/useMkrOnHat';
 import { cutMiddle, formatValue } from 'lib/string';
 import { getStatusText } from 'modules/executive/helpers/getStatusText';
 import { isDefaultNetwork } from 'modules/web3/helpers/networks';
-import VoteModal from 'modules/executive/components/VoteModal/index';
 import Stack from 'modules/app/components/layout/layouts/Stack';
 import Tabs from 'modules/app/components/Tabs';
 import PrimaryLayout from 'modules/app/components/layout/layouts/Primary';
@@ -132,36 +131,6 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
           proposal['title'] ? proposal['title'] : proposal.address
         }.`}
       />
-
-      {voting && <VoteModal close={close} proposal={proposal} />}
-      {account && bpi === 0 && (
-        <Box
-          sx={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            backgroundColor: 'surface',
-            width: '100vw',
-            borderTopLeftRadius: 'roundish',
-            borderTopRightRadius: 'roundish',
-            px: 3,
-            py: 4,
-            border: '1px solid #D4D9E1',
-            zIndex: 10
-          }}
-        >
-          <Button
-            variant="primaryLarge"
-            onClick={() => {
-              setVoting(true);
-            }}
-            sx={{ width: '100%' }}
-            disabled={hasVotedFor && votedProposals && votedProposals.length === 1}
-          >
-            Vote for this proposal
-          </Button>
-        </Box>
-      )}
       <SidebarLayout>
         <Box>
           <InternalLink href="/executive" title="View executive proposals">
@@ -172,8 +141,7 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
               </Flex>
             </Button>
           </InternalLink>
-          <Card sx={{ p: [0, 0], position: 'relative' }}>
-            <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
+          <Card sx={{ p: [0, 0] }}>
             <Heading pt={[3, 4]} px={[3, 4]} pb="3" sx={{ fontSize: [5, 6] }}>
               {proposal.title ? proposal.title : proposal.address}
             </Heading>
@@ -275,26 +243,6 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
           </Card>
         </Box>
         <Stack gap={3} sx={{ mb: [5, 0] }}>
-          {account && bpi !== 0 && (
-            <Box sx={{ mt: 4, pt: 3 }}>
-              <Card variant="compact" sx={{ position: 'relative' }}>
-                <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
-                <Text sx={{ fontSize: 5 }}>
-                  {proposal.title ? proposal.title : cutMiddle(proposal.address)}
-                </Text>
-                <Button
-                  variant="primaryLarge"
-                  onClick={() => {
-                    setVoting(true);
-                  }}
-                  sx={{ width: '100%', mt: 3 }}
-                  disabled={hasVotedFor && votedProposals && votedProposals.length === 1}
-                >
-                  Vote for this proposal
-                </Button>
-              </Card>
-            </Box>
-          )}
           <Box>
             <Flex sx={{ mt: 3, mb: 2, alignItems: 'center', justifyContent: 'space-between' }}>
               <Heading as="h3" variant="microHeading" sx={{ mr: 1 }}>
@@ -308,8 +256,7 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
               </Flex>
             </Flex>
             <ErrorBoundary componentName="Executive Supporters">
-              <Card variant="compact" p={3} sx={{ position: 'relative' }}>
-                <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
+              <Card variant="compact" p={3}>
                 <Box>
                   {!allSupporters && !supportersError && (
                     <Flex

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -172,7 +172,8 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
               </Flex>
             </Button>
           </InternalLink>
-          <Card sx={{ p: [0, 0] }}>
+          <Card sx={{ p: [0, 0], position: 'relative' }}>
+            <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
             <Heading pt={[3, 4]} px={[3, 4]} pb="3" sx={{ fontSize: [5, 6] }}>
               {proposal.title ? proposal.title : proposal.address}
             </Heading>
@@ -276,7 +277,8 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
         <Stack gap={3} sx={{ mb: [5, 0] }}>
           {account && bpi !== 0 && (
             <Box sx={{ mt: 4, pt: 3 }}>
-              <Card variant="compact">
+              <Card variant="compact" sx={{ position: 'relative' }}>
+                <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
                 <Text sx={{ fontSize: 5 }}>
                   {proposal.title ? proposal.title : cutMiddle(proposal.address)}
                 </Text>
@@ -306,7 +308,8 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
               </Flex>
             </Flex>
             <ErrorBoundary componentName="Executive Supporters">
-              <Card variant="compact" p={3}>
+              <Card variant="compact" p={3} sx={{ position: 'relative' }}>
+                <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
                 <Box>
                   {!allSupporters && !supportersError && (
                     <Flex

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -386,7 +386,7 @@ export default function ProposalPage({
   const proposalId = query['proposal-id'] as string;
 
   // Try to fetch Sky executive if legacy executive fails or isn't found
-  const { executive: skyExecutive, error: skyError } = useSkyExecutiveDetail(
+  const { executive: skyExecutive, error: skyError, isValidating: isSkyExecutiveLoading } = useSkyExecutiveDetail(
     (!prefetchedProposal || error) && proposalId ? proposalId : undefined
   );
 
@@ -428,7 +428,12 @@ export default function ProposalPage({
     );
   }
 
-  // Now check for actual errors or missing proposals AFTER fallback is resolved
+  // Show loading state if Sky executive is still loading
+  if (isSkyExecutiveLoading && (!prefetchedProposal || error)) {
+    return <LoadingIndicator />;
+  }
+
+  // Now check for actual errors or missing proposals AFTER fallback is resolved and loading is complete
   if ((error || (isDefaultNetwork(network) && !prefetchedProposal?.key)) && skyError) {
     return (
       <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -507,9 +507,21 @@ export default function ProposalPage({
     );
   }
 
+  // Check if proposal is null before rendering
+  if (!proposal) {
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage
+          statusCode={404}
+          title="Executive proposal either does not exist, or could not be fetched at this time"
+        />
+      </PrimaryLayout>
+    );
+  }
+
   return (
     <ErrorBoundary componentName="Executive Page">
-      <ProposalView proposal={proposal as Proposal} spellDiffs={[]} />
+      <ProposalView proposal={proposal} spellDiffs={[]} />
     </ErrorBoundary>
   );
 }

--- a/pages/legacy-executive.tsx
+++ b/pages/legacy-executive.tsx
@@ -306,7 +306,12 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
         <SidebarLayout>
           <Box>
             <Stack gap={3}>
-              <Heading as="h1">Legacy Executive Proposals</Heading>
+              <Flex sx={{ justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                <Heading as="h1">Legacy Executive Proposals</Heading>
+                <InternalLink href="/executive" title="Sky Executive Proposals">
+                  <Button variant="outline">Sky Executives</Button>
+                </InternalLink>
+              </Flex>
               {!isLoadingInitialData && (
                 <Stack gap={4} sx={{ mb: 4 }}>
                   {flattenedProposals
@@ -321,6 +326,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
                             account={account}
                             votedProposals={votedProposals}
                             mkrOnHat={mkrOnHat}
+                            isLegacy={true}
                           />
                         </Box>
                       );
@@ -384,6 +390,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
                             account={account}
                             votedProposals={votedProposals}
                             mkrOnHat={mkrOnHat}
+                            isLegacy={true}
                           />
                         </Box>
                       ))}

--- a/pages/legacy-executive.tsx
+++ b/pages/legacy-executive.tsx
@@ -423,21 +423,6 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
             </Stack>
           </Box>
           <Stack gap={3}>
-            <Box sx={{ mb: 3 }}>
-              <Heading mt={3} mb={2} as="h3" variant="microHeading">
-                Custom Spell Voting
-              </Heading>
-              <Card variant="compact">
-                <Text as="p" sx={{ mb: 3, color: 'textSecondary' }}>
-                  It is also possible to vote on a custom spell address—only use this in case of emergencies!
-                </Text>
-                <Box>
-                  <InternalLink href={'/custom-spell'} title="View custom spell voting page">
-                    <Text color="accentBlue">View Custom Spell Voting Page</Text>
-                  </InternalLink>
-                </Box>
-              </Card>
-            </Box>
             <ErrorBoundary componentName="System Info">
               <SystemStatsSidebar
                 fields={['chief contract', 'mkr in chief', 'savings rate', 'total dai', 'debt ceiling']}

--- a/pages/legacy-executive/[proposal-id].tsx
+++ b/pages/legacy-executive/[proposal-id].tsx
@@ -31,7 +31,7 @@ import ResourceBox from 'modules/app/components/ResourceBox';
 import { StatBox } from 'modules/app/components/StatBox';
 import { SpellEffectsTab } from 'modules/executive/components/SpellEffectsTab';
 import { InternalLink } from 'modules/app/components/InternalLink';
-import { CMSProposal, Proposal, SpellData, SpellDiff, isSkyExecutive } from 'modules/executive/types';
+import { CMSProposal, Proposal, SpellData, SpellDiff } from 'modules/executive/types';
 import { HeadComponent } from 'modules/app/components/layout/Head';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { useAccount } from 'modules/app/hooks/useAccount';
@@ -44,8 +44,6 @@ import EtherscanLink from 'modules/web3/components/EtherscanLink';
 import { trimProposalKey } from 'modules/executive/helpers/trimProposalKey';
 import { parseEther } from 'viem';
 import { useNetwork } from 'modules/app/hooks/useNetwork';
-import { useSkyExecutiveDetail } from 'modules/executive/hooks/useSkyExecutiveDetail';
-import SkyExecutiveDetailView from 'modules/executive/components/SkyExecutiveDetailView';
 
 type Props = {
   proposal: Proposal;
@@ -164,11 +162,11 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
       )}
       <SidebarLayout>
         <Box>
-          <InternalLink href="/executive" title="View executive proposals">
+          <InternalLink href="/legacy-executive" title="View legacy executive proposals">
             <Button variant="mutedOutline" mb={2}>
               <Flex sx={{ alignItems: 'center', whiteSpace: 'nowrap' }}>
                 <Icon name="chevron_left" sx={{ size: 2, mr: 2 }} />
-                Back to Execs
+                Back to Legacy Execs
               </Flex>
             </Button>
           </InternalLink>
@@ -433,12 +431,6 @@ export default function ProposalPage({
   const router = useRouter();
   const { query } = router;
   const network = useNetwork();
-  const proposalId = query['proposal-id'] as string;
-
-  // Try to fetch Sky executive if legacy executive fails or isn't found
-  const { executive: skyExecutive, error: skyError } = useSkyExecutiveDetail(
-    (!prefetchedProposal || error) && proposalId ? proposalId : undefined
-  );
 
   /**Disabling spell-effects until multi-transactions endpoint is ready */
   // const spellAddress = prefetchedProposal?.address;
@@ -469,17 +461,8 @@ export default function ProposalPage({
     return <LoadingIndicator />;
   }
 
-  // If we have a Sky executive, render it
-  if (skyExecutive) {
-    return (
-      <ErrorBoundary componentName="Sky Executive Page">
-        <SkyExecutiveDetailView executive={skyExecutive} />
-      </ErrorBoundary>
-    );
-  }
-
   // Now check for actual errors or missing proposals AFTER fallback is resolved
-  if ((error || (isDefaultNetwork(network) && !prefetchedProposal?.key)) && skyError) {
+  if (error || (isDefaultNetwork(network) && !prefetchedProposal?.key)) {
     return (
       <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
         <ErrorPage
@@ -497,15 +480,6 @@ export default function ProposalPage({
 
   const proposal = isDefaultNetwork(network) ? prefetchedProposal : _proposal;
   // const spellDiffs = prefetchedSpellDiffs.length > 0 ? prefetchedSpellDiffs : diffs;
-
-  // If we have a legacy proposal, check if it's actually a Sky executive
-  if (proposal && isSkyExecutive(proposal)) {
-    return (
-      <ErrorBoundary componentName="Sky Executive Page">
-        <SkyExecutiveDetailView executive={proposal} />
-      </ErrorBoundary>
-    );
-  }
 
   return (
     <ErrorBoundary componentName="Executive Page">
@@ -545,7 +519,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   const paths = proposals
     .slice(0, MAX_PROPOSALS)
-    .map(proposal => `/executive/${trimProposalKey(proposal.key)}`);
+    .map(proposal => `/legacy-executive/${trimProposalKey(proposal.key)}`);
 
   return {
     paths,

--- a/pages/legacy-executive/[proposal-id].tsx
+++ b/pages/legacy-executive/[proposal-id].tsx
@@ -170,7 +170,8 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
               </Flex>
             </Button>
           </InternalLink>
-          <Card sx={{ p: [0, 0] }}>
+          <Card sx={{ p: [0, 0], position: 'relative' }}>
+            <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
             <Heading pt={[3, 4]} px={[3, 4]} pb="3" sx={{ fontSize: [5, 6] }}>
               {proposal.title ? proposal.title : proposal.address}
             </Heading>

--- a/pages/legacy-executive/[proposal-id].tsx
+++ b/pages/legacy-executive/[proposal-id].tsx
@@ -19,10 +19,9 @@ import { useSpellData } from 'modules/executive/hooks/useSpellData';
 import { useVotedProposals } from 'modules/executive/hooks/useVotedProposals';
 import { useHat } from 'modules/executive/hooks/useHat';
 import { useMkrOnHat } from 'modules/executive/hooks/useMkrOnHat';
-import { cutMiddle, formatValue } from 'lib/string';
+import { formatValue } from 'lib/string';
 import { getStatusText } from 'modules/executive/helpers/getStatusText';
 import { isDefaultNetwork } from 'modules/web3/helpers/networks';
-import VoteModal from 'modules/executive/components/VoteModal/index';
 import Stack from 'modules/app/components/layout/layouts/Stack';
 import Tabs from 'modules/app/components/Tabs';
 import PrimaryLayout from 'modules/app/components/layout/layouts/Primary';
@@ -130,36 +129,6 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
           proposal['title'] ? proposal['title'] : proposal.address
         }.`}
       />
-
-      {voting && <VoteModal close={close} proposal={proposal} />}
-      {account && bpi === 0 && (
-        <Box
-          sx={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            backgroundColor: 'surface',
-            width: '100vw',
-            borderTopLeftRadius: 'roundish',
-            borderTopRightRadius: 'roundish',
-            px: 3,
-            py: 4,
-            border: '1px solid #D4D9E1',
-            zIndex: 10
-          }}
-        >
-          <Button
-            variant="primaryLarge"
-            onClick={() => {
-              setVoting(true);
-            }}
-            sx={{ width: '100%' }}
-            disabled={hasVotedFor && votedProposals && votedProposals.length === 1}
-          >
-            Vote for this proposal
-          </Button>
-        </Box>
-      )}
       <SidebarLayout>
         <Box>
           <InternalLink href="/legacy-executive" title="View legacy executive proposals">
@@ -170,8 +139,7 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
               </Flex>
             </Button>
           </InternalLink>
-          <Card sx={{ p: [0, 0], position: 'relative' }}>
-            <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>Sky Governance</Badge>
+          <Card sx={{ p: [0, 0] }}>
             <Heading pt={[3, 4]} px={[3, 4]} pb="3" sx={{ fontSize: [5, 6] }}>
               {proposal.title ? proposal.title : proposal.address}
             </Heading>
@@ -273,25 +241,6 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
           </Card>
         </Box>
         <Stack gap={3} sx={{ mb: [5, 0] }}>
-          {account && bpi !== 0 && (
-            <Box sx={{ mt: 4, pt: 3 }}>
-              <Card variant="compact">
-                <Text sx={{ fontSize: 5 }}>
-                  {proposal.title ? proposal.title : cutMiddle(proposal.address)}
-                </Text>
-                <Button
-                  variant="primaryLarge"
-                  onClick={() => {
-                    setVoting(true);
-                  }}
-                  sx={{ width: '100%', mt: 3 }}
-                  disabled={hasVotedFor && votedProposals && votedProposals.length === 1}
-                >
-                  Vote for this proposal
-                </Button>
-              </Card>
-            </Box>
-          )}
           <Box>
             <Flex sx={{ mt: 3, mb: 2, alignItems: 'center', justifyContent: 'space-between' }}>
               <Heading as="h3" variant="microHeading" sx={{ mr: 1 }}>

--- a/pages/legacy-polling.tsx
+++ b/pages/legacy-polling.tsx
@@ -44,6 +44,7 @@ import { PollingPageProps } from 'modules/polling/types/pollsResponse';
 import { PollOrderByEnum, PollStatusEnum } from 'modules/polling/polling.constants';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { useNetwork } from 'modules/app/hooks/useNetwork';
+import { InternalLink } from 'modules/app/components/InternalLink';
 
 const emptyStats = {
   active: 0,
@@ -320,6 +321,12 @@ const PollingOverview = ({
         </Flex>
         <SidebarLayout>
           <Box>
+            <Flex sx={{ justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+              <Heading as="h1">Legacy Polls</Heading>
+              <InternalLink href="/polling" title="Sky Polls">
+                <Button variant="outline">Sky Polls</Button>
+              </InternalLink>
+            </Flex>
             {[...activePolls, ...endedPolls].length === 0 && !loading && (
               <Flex sx={{ flexDirection: 'column', alignItems: 'center', pt: [5, 5, 5, 6] }}>
                 <Flex

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -128,12 +128,6 @@ const SkyPollView = ({ poll }: { poll: SkyPollDetailResponse }) => {
                   >
                     Posted {formatDateWithTime(new Date(poll.startDate))} | Poll ID {poll.pollId}
                   </Text>
-                  <CountdownTimer
-                    key={poll.multiHash}
-                    endText="Poll ended"
-                    endDate={new Date(poll.endDate)}
-                    sx={{ ml: [0, 'auto'] }}
-                  />
                 </Flex>
 
                 <Flex sx={{ mb: 2, flexDirection: 'column' }}>
@@ -148,6 +142,13 @@ const SkyPollView = ({ poll }: { poll: SkyPollDetailResponse }) => {
                       </Box>
                     ))}
                   </Flex>
+
+                  <CountdownTimer
+                    key={poll.multiHash}
+                    endText="Poll ended"
+                    endDate={new Date(poll.endDate)}
+                    sx={{ mb: 2 }}
+                  />
 
                   <Flex sx={{ justifyContent: 'space-between', mb: 2, flexDirection: 'column' }}>
                     {poll.discussionLink && (

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -11,7 +11,7 @@ import { GetServerSideProps } from 'next';
 import ErrorPage from 'modules/app/components/ErrorPage';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { Card, Flex, Divider, Heading, Text, Box, Button } from 'theme-ui';
+import { Card, Flex, Divider, Heading, Text, Box, Button, Badge } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import Icon from 'modules/app/components/Icon';
 import { formatDateWithTime } from 'lib/datetime';
@@ -112,7 +112,10 @@ const SkyPollView = ({ poll }: { poll: SkyPollDetailResponse }) => {
               )}
             </Flex>
           </Flex>
-          <Card sx={{ p: [0, 0] }}>
+          <Card sx={{ p: [0, 0], position: 'relative' }}>
+            <Badge variant="sky" sx={{ position: 'absolute', top: 3, right: 3 }}>
+              Sky Governance
+            </Badge>
             <Flex sx={{ flexDirection: 'column', px: [3, 4], pt: [3, 4] }}>
               <Box>
                 <Flex sx={{ justifyContent: 'space-between', flexDirection: ['column', 'row'] }}>
@@ -287,7 +290,7 @@ const SkyPollView = ({ poll }: { poll: SkyPollDetailResponse }) => {
           {/* Read-only notice for Sky polls */}
           <Card sx={{ p: 3, backgroundColor: 'background', border: '1px solid', borderColor: 'muted' }}>
             <Flex sx={{ alignItems: 'center', justifyContent: 'center' }}>
-              <Icon name="info" sx={{ mr: 2, color: 'primary' }} />
+              <Icon name="info" sx={{ mr: 2, color: 'primary', size: 4 }} />
               <Text sx={{ textAlign: 'center', color: 'textSecondary' }}>
                 This is a Sky governance poll. Voting is only available on{' '}
                 <ExternalLink href="https://vote.sky.money" title="Sky voting portal">

--- a/playwright/executive.spec.ts
+++ b/playwright/executive.spec.ts
@@ -86,6 +86,9 @@ test.describe('Sky Executive Page', () => {
       await skyExecutivePage.verifyExecutivesVisible();
       const executiveCount = await skyExecutivePage.getExecutiveCount();
       test.expect(executiveCount).toBe(2);
+      
+      // Check Sky Governance badge is visible on executive cards
+      await expect(skyExecutivePage.page.getByText('Sky Governance')).toBeVisible();
     });
 
     // await test('verify Sky Portal button is visible', async () => {

--- a/playwright/executive.spec.ts
+++ b/playwright/executive.spec.ts
@@ -88,7 +88,7 @@ test.describe('Sky Executive Page', () => {
       test.expect(executiveCount).toBe(2);
       
       // Check Sky Governance badge is visible on executive cards
-      await expect(skyExecutivePage.page.getByText('Sky Governance')).toBeVisible();
+      await expect(skyExecutivePage.page.getByText('Sky Governance').first()).toBeVisible();
     });
 
     // await test('verify Sky Portal button is visible', async () => {

--- a/playwright/fixtures/polling.ts
+++ b/playwright/fixtures/polling.ts
@@ -14,7 +14,7 @@ export class LegacyPollingPage {
   }
 
   private initializeLocators() {
-    this.pollHeading = this.page.getByRole('heading', { name: /Active Polls|Ended Polls|Legacy Polls/ });
+    this.pollHeading = this.page.locator('h1').filter({ hasText: /Legacy Polls/ });
     this.pollOverviewCard = this.page.locator('[data-testid="poll-overview-card"]');
     this.votingWeightText = this.page.locator('[data-testid="voting-weight"]');
   }

--- a/playwright/fixtures/sky-executive-detail.ts
+++ b/playwright/fixtures/sky-executive-detail.ts
@@ -1,0 +1,149 @@
+import { expect, Page } from '@playwright/test';
+
+export class SkyExecutiveDetailPage {
+  readonly page: Page;
+
+  // Locators
+  private backToExecsButton: any;
+  private previousExecButton: any;
+  private nextExecButton: any;
+  private executiveTitle: any;
+  private executiveBlurb: any;
+  private skyPortalLink: any;
+  private spellAddress: any;
+  private skySupport: any;
+  private supportersCount: any;
+  private supportersTab: any;
+  private executiveDetailTab: any;
+  private supportersTable: any;
+  private supporterAddress: any;
+  private skyAmountColumn: any;
+  private percentageColumn: any;
+  private showAllSupportersButton: any;
+  private sortBySkyButton: any;
+  private sortByPercentageButton: any;
+  private executiveStatus: any;
+  private totalSkySupport: any;
+  private totalSupporters: any;
+  private readOnlyNotice: any;
+  private skyVotingLink: any;
+  private executiveContent: any;
+  private governingProposalBadge: any;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.initializeLocators();
+  }
+
+  private initializeLocators() {
+    this.backToExecsButton = this.page.getByRole('button', { name: /Back to Execs/ });
+    this.previousExecButton = this.page.getByRole('button', { name: /Previous/ });
+    this.nextExecButton = this.page.getByRole('button', { name: /Next/ });
+    this.executiveTitle = this.page.getByRole('heading', { level: 1 });
+    this.executiveBlurb = this.page.getByText(/This is a test executive/);
+    this.skyPortalLink = this.page.getByRole('link', { name: 'View on Sky Portal' });
+    this.spellAddress = this.page.getByText(/Spell Address/);
+    this.skySupport = this.page.getByText(/SKY Support/);
+    this.supportersCount = this.page.getByText(/Supporters/);
+    this.supportersTab = this.page.getByRole('tab', { name: 'Supporters' });
+    this.executiveDetailTab = this.page.getByRole('tab', { name: 'Executive Detail' });
+    this.supportersTable = this.page.locator('[data-testid="supporters-table"]');
+    this.supporterAddress = this.page.locator('text=/0x[a-fA-F0-9]{4}\.\.\./');
+    this.skyAmountColumn = this.page.locator('text=/SKY$/');
+    this.percentageColumn = this.page.locator('text=/%$/');
+    this.showAllSupportersButton = this.page.getByRole('button', { name: /Show all.*supporters/ });
+    this.sortBySkyButton = this.page.getByRole('button', { name: 'SKY Support' });
+    this.sortByPercentageButton = this.page.getByRole('button', { name: 'Percentage' });
+    this.executiveStatus = this.page.locator('[data-testid="sky-executive-status"]');
+    this.totalSkySupport = this.page.getByText(/Total SKY Support/);
+    this.totalSupporters = this.page.getByText(/Total Supporters/);
+    this.readOnlyNotice = this.page.getByText(/This is a Sky governance executive/);
+    this.skyVotingLink = this.page.getByRole('link', { name: 'vote.sky.money' });
+    this.executiveContent = this.page.locator('[data-testid="executive-detail"]');
+    this.governingProposalBadge = this.page.getByText('Governing Proposal');
+  }
+
+  async goto(executiveKey: string) {
+    await this.page.goto(`/executive/${executiveKey}`);
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async waitForPageLoad() {
+    await expect(this.executiveTitle).toBeVisible();
+  }
+
+  async verifyExecutiveInformation() {
+    await expect(this.executiveTitle).toBeVisible();
+    await expect(this.executiveBlurb).toBeVisible();
+    await expect(this.spellAddress).toBeVisible();
+    await expect(this.skySupport).toBeVisible();
+    await expect(this.supportersCount).toBeVisible();
+  }
+
+  async verifyExternalLinks() {
+    await expect(this.skyPortalLink).toBeVisible();
+    await expect(this.skyPortalLink).toHaveAttribute('href', /vote\.sky\.money/);
+  }
+
+  async verifySupportersTab() {
+    await this.supportersTab.click();
+    await expect(this.supportersTable).toBeVisible();
+    await expect(this.supporterAddress.first()).toBeVisible();
+    await expect(this.skyAmountColumn.first()).toBeVisible();
+    await expect(this.percentageColumn.first()).toBeVisible();
+  }
+
+  async verifyExecutiveDetailTab() {
+    await this.executiveDetailTab.click();
+    await expect(this.executiveContent).toBeVisible();
+  }
+
+  async verifySorting() {
+    // Test SKY Support sorting
+    await this.sortBySkyButton.click();
+    await this.page.waitForTimeout(500); // Allow sorting to complete
+    
+    // Test Percentage sorting
+    await this.sortByPercentageButton.click();
+    await this.page.waitForTimeout(500); // Allow sorting to complete
+  }
+
+  async verifyShowAllSupporters() {
+    const initialCount = await this.supporterAddress.count();
+    await this.showAllSupportersButton.click();
+    await this.page.waitForTimeout(500);
+    const newCount = await this.supporterAddress.count();
+    expect(newCount).toBeGreaterThanOrEqual(initialCount);
+  }
+
+  async verifyNavigationControls() {
+    await expect(this.backToExecsButton).toBeVisible();
+    // Previous/Next buttons may not always be visible depending on context
+  }
+
+  async clickBackToExecs() {
+    await this.backToExecsButton.click();
+    await expect(this.page).toHaveURL('/executive');
+  }
+
+  async verifyExecutiveStatus() {
+    await expect(this.executiveStatus).toBeVisible();
+  }
+
+  async verifyReadOnlyNotice() {
+    await expect(this.readOnlyNotice).toBeVisible();
+    await expect(this.skyVotingLink).toBeVisible();
+    await expect(this.skyVotingLink).toHaveAttribute('href', 'https://vote.sky.money');
+  }
+
+  async verifyGoverningProposalBadge(shouldBeVisible: boolean = false) {
+    if (shouldBeVisible) {
+      await expect(this.governingProposalBadge).toBeVisible();
+    }
+  }
+
+  async verifySummaryStats() {
+    await expect(this.totalSkySupport).toBeVisible();
+    await expect(this.totalSupporters).toBeVisible();
+  }
+}

--- a/playwright/sky-executive-detail.spec.ts
+++ b/playwright/sky-executive-detail.spec.ts
@@ -130,6 +130,9 @@ test.describe('Sky Executive Detail Page', () => {
       
       // Check supporters count
       await expect(page.getByText(/5/)).toBeVisible();
+      
+      // Check Sky Governance badge
+      await expect(page.getByText('Sky Governance')).toBeVisible();
     });
 
     await test.step('verify external links', async () => {

--- a/playwright/sky-executive-detail.spec.ts
+++ b/playwright/sky-executive-detail.spec.ts
@@ -1,0 +1,363 @@
+import { test, expect } from './fixtures/base';
+import { SkyExecutiveDetailPage } from './fixtures/sky-executive-detail';
+import './forkVnet';
+
+test.describe('Sky Executive Detail Page', () => {
+  const mockExecutiveDetail = {
+    title: 'Test Sky Executive Detail',
+    proposalBlurb: 'This is a test executive proposal for the detail page',
+    key: 'test-sky-executive-detail',
+    address: '0x1234567890123456789012345678901234567890',
+    date: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    content: '<p>This is the detailed content of the executive proposal</p>',
+    active: true,
+    proposalLink: 'https://vote.sky.money/executive/test-sky-executive-detail',
+    spellData: {
+      hasBeenCast: false,
+      hasBeenScheduled: true,
+      nextCastTime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      datePassed: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(),
+      dateExecuted: '',
+      skySupport: '750000',
+      executiveHash: '0xabcdef123456',
+      officeHours: 'true'
+    },
+    supporters: [
+      {
+        address: '0x1234567890123456789012345678901234567890',
+        skySupport: '250000',
+        percentage: 33.33
+      },
+      {
+        address: '0x2345678901234567890123456789012345678901',
+        skySupport: '200000',
+        percentage: 26.67
+      },
+      {
+        address: '0x3456789012345678901234567890123456789012',
+        skySupport: '150000',
+        percentage: 20.00
+      },
+      {
+        address: '0x4567890123456789012345678901234567890123',
+        skySupport: '100000',
+        percentage: 13.33
+      },
+      {
+        address: '0x5678901234567890123456789012345678901234',
+        skySupport: '50000',
+        percentage: 6.67
+      }
+    ],
+    ctx: {
+      prev: { key: 'previous-executive-key' },
+      next: { key: 'next-executive-key' }
+    }
+  };
+
+  const mockGoverningExecutive = {
+    ...mockExecutiveDetail,
+    title: 'Test Governing Executive',
+    key: 'test-governing-executive',
+    spellData: {
+      ...mockExecutiveDetail.spellData,
+      hasBeenCast: true,
+      hasBeenScheduled: true,
+      dateExecuted: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString()
+    }
+  };
+
+  test.beforeEach(async ({ page }) => {
+    // Mock the Sky executive detail API endpoint
+    await page.route('**/api/sky/executives/test-sky-executive-detail', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockExecutiveDetail)
+      });
+    });
+
+    await page.route('**/api/sky/executives/test-governing-executive', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockGoverningExecutive)
+      });
+    });
+
+    // Mock external Sky API for server-side rendering fallback
+    await page.route('**/vote.sky.money/api/executive/test-sky-executive-detail', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockExecutiveDetail)
+      });
+    });
+
+    await page.route('**/vote.sky.money/api/executive/test-governing-executive', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockGoverningExecutive)
+      });
+    });
+  });
+
+  test('displays executive detail page correctly', async ({ page }) => {
+    const skyExecutiveDetailPage = new SkyExecutiveDetailPage(page);
+
+    await test.step('navigate to executive detail page', async () => {
+      await skyExecutiveDetailPage.goto('test-sky-executive-detail');
+      await skyExecutiveDetailPage.waitForPageLoad();
+    });
+
+    await test.step('verify page title and metadata', async () => {
+      await expect(page).toHaveTitle(/Test Sky Executive Detail/);
+    });
+
+    await test.step('verify executive information is displayed', async () => {
+      await skyExecutiveDetailPage.verifyExecutiveInformation();
+      
+      // Check executive key and dates
+      await expect(page.getByText(/Executive Key test-sky-executive-detail/)).toBeVisible();
+      await expect(page.getByText(/Posted/)).toBeVisible();
+      
+      // Check spell address
+      await expect(page.getByText(/0x1234567890123456789012345678901234567890/)).toBeVisible();
+      
+      // Check SKY support
+      await expect(page.getByText(/750,000/)).toBeVisible();
+      
+      // Check supporters count
+      await expect(page.getByText(/5/)).toBeVisible();
+    });
+
+    await test.step('verify external links', async () => {
+      await skyExecutiveDetailPage.verifyExternalLinks();
+    });
+
+    await test.step('verify read-only notice', async () => {
+      await skyExecutiveDetailPage.verifyReadOnlyNotice();
+    });
+
+    await test.step('verify executive status', async () => {
+      await skyExecutiveDetailPage.verifyExecutiveStatus();
+      await expect(page.getByText(/Scheduled/)).toBeVisible();
+    });
+  });
+
+  test('displays supporters tab correctly', async ({ page }) => {
+    const skyExecutiveDetailPage = new SkyExecutiveDetailPage(page);
+
+    await test.step('navigate to executive detail page', async () => {
+      await skyExecutiveDetailPage.goto('test-sky-executive-detail');
+      await skyExecutiveDetailPage.waitForPageLoad();
+    });
+
+    await test.step('verify supporters tab is default', async () => {
+      const supportersTab = page.getByRole('tab', { name: 'Supporters' });
+      await expect(supportersTab).toBeVisible();
+    });
+
+    await test.step('verify supporters table is displayed', async () => {
+      await skyExecutiveDetailPage.verifySupportersTab();
+      
+      // Check supporter addresses are displayed (truncated format)
+      await expect(page.getByText(/0x1234.../)).toBeVisible();
+      await expect(page.getByText(/0x2345.../)).toBeVisible();
+      
+      // Check SKY amounts
+      await expect(page.getByText(/250,000 SKY/)).toBeVisible();
+      await expect(page.getByText(/200,000 SKY/)).toBeVisible();
+      
+      // Check percentages
+      await expect(page.getByText(/33.33%/)).toBeVisible();
+      await expect(page.getByText(/26.67%/)).toBeVisible();
+    });
+
+    await test.step('verify summary stats', async () => {
+      await skyExecutiveDetailPage.verifySummaryStats();
+      await expect(page.getByText(/750,000 SKY/)).toBeVisible();
+      await expect(page.getByText(/5/)).toBeVisible();
+    });
+
+    await test.step('verify sorting functionality', async () => {
+      await skyExecutiveDetailPage.verifySorting();
+    });
+  });
+
+  test('displays executive detail tab correctly', async ({ page }) => {
+    const skyExecutiveDetailPage = new SkyExecutiveDetailPage(page);
+
+    await test.step('navigate to executive detail page', async () => {
+      await skyExecutiveDetailPage.goto('test-sky-executive-detail');
+      await skyExecutiveDetailPage.waitForPageLoad();
+    });
+
+    await test.step('switch to executive detail tab', async () => {
+      await skyExecutiveDetailPage.verifyExecutiveDetailTab();
+    });
+
+    await test.step('verify executive content is displayed', async () => {
+      const executiveDetailContent = page.locator('[data-testid="executive-detail"]');
+      await expect(executiveDetailContent).toBeVisible();
+      await expect(executiveDetailContent).toContainText('This is the detailed content of the executive proposal');
+    });
+  });
+
+  test('navigation controls work correctly', async ({ page }) => {
+    const skyExecutiveDetailPage = new SkyExecutiveDetailPage(page);
+
+    await test.step('navigate to executive detail page', async () => {
+      await skyExecutiveDetailPage.goto('test-sky-executive-detail');
+      await skyExecutiveDetailPage.waitForPageLoad();
+    });
+
+    await test.step('verify navigation controls', async () => {
+      await skyExecutiveDetailPage.verifyNavigationControls();
+    });
+
+    await test.step('verify back to executives button', async () => {
+      // Mock the executives page
+      await page.route('**/api/sky/executives*', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([])
+        });
+      });
+      
+      await skyExecutiveDetailPage.clickBackToExecs();
+    });
+
+    await test.step('verify previous/next navigation', async () => {
+      await skyExecutiveDetailPage.goto('test-sky-executive-detail');
+      
+      // Check if previous button exists and works
+      const prevButton = page.getByRole('button', { name: /Previous/ });
+      if (await prevButton.isVisible()) {
+        await prevButton.click();
+        await expect(page).toHaveURL(/\/executive\/previous-executive-key/);
+      }
+    });
+  });
+
+  test('displays governing proposal badge correctly', async ({ page }) => {
+    const skyExecutiveDetailPage = new SkyExecutiveDetailPage(page);
+
+    await test.step('navigate to governing executive detail page', async () => {
+      await skyExecutiveDetailPage.goto('test-governing-executive');
+      await skyExecutiveDetailPage.waitForPageLoad();
+    });
+
+    await test.step('verify governing proposal badge is displayed', async () => {
+      await skyExecutiveDetailPage.verifyGoverningProposalBadge(true);
+    });
+
+    await test.step('verify executed status', async () => {
+      await expect(page.getByText(/Executed/)).toBeVisible();
+    });
+  });
+
+  test('handles executive not found error', async ({ page }) => {
+    await test.step('mock API to return 404', async () => {
+      await page.route('**/api/sky/executives/non-existent-executive', route => {
+        route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Executive not found' })
+        });
+      });
+
+      await page.route('**/vote.sky.money/api/executive/non-existent-executive', route => {
+        route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Executive not found' })
+        });
+      });
+
+      // Mock legacy executive API to also return 404
+      await page.route('**/api/executive/non-existent-executive', route => {
+        route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Executive not found' })
+        });
+      });
+    });
+
+    await test.step('navigate to non-existent executive', async () => {
+      await page.goto('/executive/non-existent-executive');
+      await page.waitForLoadState('networkidle');
+    });
+
+    await test.step('verify error page is displayed', async () => {
+      await expect(page.getByText(/Executive proposal either does not exist/)).toBeVisible();
+    });
+  });
+
+  test('handles API errors gracefully', async ({ page }) => {
+    await test.step('mock API to return 500 error', async () => {
+      await page.route('**/api/sky/executives/error-executive', route => {
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Internal server error' })
+        });
+      });
+
+      await page.route('**/vote.sky.money/api/executive/error-executive', route => {
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Internal server error' })
+        });
+      });
+
+      await page.route('**/api/executive/error-executive', route => {
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Internal server error' })
+        });
+      });
+    });
+
+    await test.step('navigate to error executive', async () => {
+      await page.goto('/executive/error-executive');
+      await page.waitForLoadState('networkidle');
+    });
+
+    await test.step('verify error page is displayed', async () => {
+      await expect(page.getByText(/Executive proposal either does not exist/)).toBeVisible();
+    });
+  });
+
+  test('supporters table shows no supporters message when empty', async ({ page }) => {
+    const emptyExecutive = {
+      ...mockExecutiveDetail,
+      key: 'empty-executive',
+      supporters: []
+    };
+
+    await test.step('mock executive with no supporters', async () => {
+      await page.route('**/api/sky/executives/empty-executive', route => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(emptyExecutive)
+        });
+      });
+    });
+
+    await test.step('navigate to executive with no supporters', async () => {
+      await page.goto('/executive/empty-executive');
+      await page.waitForLoadState('networkidle');
+    });
+
+    await test.step('verify no supporters message', async () => {
+      await expect(page.getByText(/Currently there are no supporters/)).toBeVisible();
+    });
+  });
+});

--- a/playwright/sky-poll-detail.spec.ts
+++ b/playwright/sky-poll-detail.spec.ts
@@ -155,6 +155,9 @@ test.describe('Sky Poll Detail Page', () => {
       // Check external links
       await expect(page.getByRole('link', { name: 'Forum Discussion' })).toBeVisible();
       await expect(page.getByRole('link', { name: 'Review resources on GitHub' })).toBeVisible();
+      
+      // Check Sky Governance badge
+      await expect(page.getByText('Sky Governance')).toBeVisible();
     });
 
     await test.step('verify read-only notice', async () => {

--- a/scripts/test-sky-executive-api.js
+++ b/scripts/test-sky-executive-api.js
@@ -1,0 +1,151 @@
+/**
+ * Simple test script to verify Sky executive API endpoint
+ * Run with: node scripts/test-sky-executive-api.js
+ */
+
+const fetch = require('node-fetch');
+
+async function testSkyExecutiveAPI() {
+  console.log('Testing Sky Executive API...\n');
+  
+  // Test 1: Test Sky executive detail endpoint
+  try {
+    console.log('1. Testing Sky executive detail endpoint...');
+    const response = await fetch('https://vote.sky.money/api/executive', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      // Add timeout
+      timeout: 10000
+    });
+    
+    if (!response.ok) {
+      console.log(`❌ Sky executives API returned status: ${response.status}`);
+      return false;
+    }
+    
+    const data = await response.json();
+    console.log('✅ Sky executives API is working');
+    console.log(`   Found ${data.length} executives`);
+    
+    if (data.length > 0) {
+      const firstExec = data[0];
+      console.log(`   First executive key: ${firstExec.key}`);
+      console.log(`   First executive title: ${firstExec.title}`);
+      
+      // Test 2: Test individual executive detail
+      console.log('\n2. Testing individual executive detail...');
+      const detailResponse = await fetch(`https://vote.sky.money/api/executive/${firstExec.key}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        timeout: 10000
+      });
+      
+      if (!detailResponse.ok) {
+        console.log(`❌ Sky executive detail API returned status: ${detailResponse.status}`);
+        return false;
+      }
+      
+      const detailData = await detailResponse.json();
+      console.log('✅ Sky executive detail API is working');
+      console.log(`   Executive title: ${detailData.title}`);
+      console.log(`   Executive key: ${detailData.key}`);
+      console.log(`   Executive address: ${detailData.address}`);
+      console.log(`   SKY support: ${detailData.spellData?.skySupport || 'N/A'}`);
+      console.log(`   Has been cast: ${detailData.spellData?.hasBeenCast || false}`);
+      console.log(`   Has been scheduled: ${detailData.spellData?.hasBeenScheduled || false}`);
+      console.log(`   Supporters count: ${detailData.supporters?.length || 0}`);
+      
+      return true;
+    } else {
+      console.log('⚠️  No executives found in Sky API');
+      return false;
+    }
+    
+  } catch (error) {
+    console.log(`❌ Error testing Sky executive API: ${error.message}`);
+    return false;
+  }
+}
+
+// Test our API endpoint structure
+async function testAPIStructure() {
+  console.log('\n3. Testing expected API structure...');
+  
+  try {
+    const response = await fetch('https://vote.sky.money/api/executive', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      timeout: 10000
+    });
+    
+    if (!response.ok) {
+      console.log(`❌ API structure test failed: ${response.status}`);
+      return false;
+    }
+    
+    const data = await response.json();
+    
+    if (data.length > 0) {
+      const exec = data[0];
+      
+      // Check required fields
+      const requiredFields = ['title', 'proposalBlurb', 'key', 'address', 'date', 'active', 'proposalLink', 'spellData'];
+      const missingFields = requiredFields.filter(field => !(field in exec));
+      
+      if (missingFields.length > 0) {
+        console.log(`❌ Missing required fields: ${missingFields.join(', ')}`);
+        return false;
+      }
+      
+      // Check spellData fields
+      const spellDataFields = ['hasBeenCast', 'hasBeenScheduled', 'skySupport'];
+      const missingSpellFields = spellDataFields.filter(field => !(field in exec.spellData));
+      
+      if (missingSpellFields.length > 0) {
+        console.log(`❌ Missing spellData fields: ${missingSpellFields.join(', ')}`);
+        return false;
+      }
+      
+      console.log('✅ API structure matches expected format');
+      return true;
+    } else {
+      console.log('⚠️  No executives to test structure');
+      return false;
+    }
+    
+  } catch (error) {
+    console.log(`❌ Error testing API structure: ${error.message}`);
+    return false;
+  }
+}
+
+// Run tests
+async function runTests() {
+  console.log('🚀 Starting Sky Executive API Tests\n');
+  
+  const apiTest = await testSkyExecutiveAPI();
+  const structureTest = await testAPIStructure();
+  
+  console.log('\n📊 Test Results:');
+  console.log(`   API Functionality: ${apiTest ? '✅' : '❌'}`);
+  console.log(`   API Structure: ${structureTest ? '✅' : '❌'}`);
+  
+  if (apiTest && structureTest) {
+    console.log('\n🎉 All tests passed! Sky Executive API is ready for integration.');
+  } else {
+    console.log('\n⚠️  Some tests failed. Please check the API implementation.');
+  }
+}
+
+// Only run if this file is executed directly
+if (require.main === module) {
+  runTests().catch(console.error);
+}
+
+module.exports = { testSkyExecutiveAPI, testAPIStructure };


### PR DESCRIPTION
Here is the filled-out GitHub PR template:

### What does this PR do?

This PR integrates Sky Governance executives and polls into the governance portal. It introduces new, read-only detail pages for Sky proposals, fetching data directly from the Sky API via a set of internal proxy endpoints (`/api/sky/*`).

The existing executive and polling pages have been repurposed as "legacy" pages, accessible at `/legacy-executive` and `/legacy-polling`. The primary routes (`/executive` and `/polling`) now display the new Sky proposals. The proposal detail route (`/executive/[proposal-id]`) is now a unified entry point that dynamically renders either a legacy or a Sky detail view based on the proposal type.

This implementation includes a suite of new components, hooks, API routes, and types to support the Sky governance integration.

### Steps for testing:

1.  Navigate to the `/executive` page. You should see a list of Sky executive proposals, each with a "Sky Governance" badge.
2.  Click on a Sky executive proposal. You should be directed to the `/executive/[key]` URL and see the new, read-only detail page.
3.  On the detail page, verify that the proposal's title, content, SKY support, and list of supporters are displayed correctly.
4.  Confirm the "View on Sky Portal" link is present and functional.
5.  Confirm the read-only notice indicating that voting occurs on `vote.sky.money` is visible.
6.  Navigate to the `/polling` page and verify that Sky polls are listed.
7.  Click on a Sky poll to view its dedicated detail page and check for correct data display.
8.  Navigate to `/legacy-executive` and `/legacy-polling` to verify that the old Maker proposals are still accessible and render correctly on their respective legacy detail pages (`/legacy-executive/[key]` and `/legacy-polling/[slug]`).
