### PR TITLE
Pnpm minimum release age

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.9.0
+          version: 10.17.0
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
           version: 10.17.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 script-shell = bash
+minimum-release-age=1440

--- a/package.json
+++ b/package.json
@@ -121,5 +121,6 @@
   },
   "resolutions": {
     "elliptic": "^6.6.1"
-  }
+  },
+  "packageManager": "pnpm@10.17.0"
 }


### PR DESCRIPTION
### What does this PR do?
- Specify the pnpm version to use in the package.json
- Sets the minimum release age for new packages to 24 hours, so that a new package version needs to be at least 24 hours old before it can be installed in the monorepo
- Remove old pnpm configs that were using the default values and update the preferred file for configs from the `.npmrc` file to the `pnpm-workspace.yaml` file